### PR TITLE
add support for Java 8 Time LocalDate and LocalDateTime

### DIFF
--- a/src/main/scala/com/norbitltd/spoiwo/model/Cell.scala
+++ b/src/main/scala/com/norbitltd/spoiwo/model/Cell.scala
@@ -1,20 +1,25 @@
 package com.norbitltd.spoiwo.model
 
 import java.util.{Calendar, Date}
+import java.time.{LocalDate => JLocalDate, LocalDateTime => JLocalDateTime}
 import org.joda.time.{LocalDate, DateTime}
 import com.norbitltd.spoiwo.model.enums.CellStyleInheritance
+import com.norbitltd.spoiwo.utils.JavaTimeApiConversions._
 
 sealed class CellValueType[T]
 object CellValueType {
-  implicit object StringWitness extends CellValueType[String]
-  implicit object DoubleWitness extends CellValueType[Double]
-  implicit object IntWitness extends CellValueType[Int]
-  implicit object LongWitness extends CellValueType[Long]
-  implicit object BooleanWitness extends CellValueType[Boolean]
-  implicit object DateWitness extends CellValueType[Date]
-  implicit object DateTimeWitness extends CellValueType[DateTime]
-  implicit object LocalDateWitness extends CellValueType[LocalDate]
-  implicit object CalendarWitness extends CellValueType[Calendar]
+  implicit object StringWitness         extends CellValueType[String]
+  implicit object DoubleWitness         extends CellValueType[Double]
+  implicit object BigDecimalWitness     extends CellValueType[BigDecimal]
+  implicit object IntWitness            extends CellValueType[Int]
+  implicit object LongWitness           extends CellValueType[Long]
+  implicit object BooleanWitness        extends CellValueType[Boolean]
+  implicit object DateWitness           extends CellValueType[Date]
+  implicit object DateTimeWitness       extends CellValueType[DateTime]
+  implicit object LocalDateWitness      extends CellValueType[LocalDate]
+  implicit object CalendarWitness       extends CellValueType[Calendar]
+  implicit object JLocalDateWitness     extends CellValueType[JLocalDate]
+  implicit object JLocalDateTimeWitness extends CellValueType[JLocalDateTime]
 }
 
 object Cell {
@@ -32,14 +37,17 @@ object Cell {
       } else {
         StringCell(v, indexOption, styleOption, styleInheritance)
       }
-      case v : Double => NumericCell(v, indexOption, styleOption, styleInheritance)
-      case v : Int => NumericCell(v.toDouble, indexOption, styleOption, styleInheritance)
-      case v : Long => NumericCell(v.toDouble, indexOption, styleOption, styleInheritance)
-      case v : Boolean => BooleanCell(v, indexOption, styleOption, styleInheritance)
-      case v : Date => DateCell(v, indexOption, styleOption, styleInheritance)
-      case v : DateTime => DateCell(v.toDate, indexOption, styleOption, styleInheritance)
-      case v : LocalDate => DateCell(v.toDate, indexOption, styleOption, styleInheritance)
-      case v : Calendar => CalendarCell(v, indexOption, styleOption, styleInheritance)
+      case v : Double         => NumericCell(v, indexOption, styleOption, styleInheritance)
+      case v : BigDecimal     => NumericCell(v.toDouble, indexOption, styleOption, styleInheritance)
+      case v : Int            => NumericCell(v.toDouble, indexOption, styleOption, styleInheritance)
+      case v : Long           => NumericCell(v.toDouble, indexOption, styleOption, styleInheritance)
+      case v : Boolean        => BooleanCell(v, indexOption, styleOption, styleInheritance)
+      case v : Date           => DateCell(v, indexOption, styleOption, styleInheritance)
+      case v : DateTime       => DateCell(v.toDate, indexOption, styleOption, styleInheritance)
+      case v : LocalDate      => DateCell(v.toDate, indexOption, styleOption, styleInheritance)
+      case v : JLocalDate     => DateCell(v.toDate, indexOption, styleOption, styleInheritance)
+      case v : JLocalDateTime => DateCell(v.toDate, indexOption, styleOption, styleInheritance)
+      case v : Calendar       => CalendarCell(v, indexOption, styleOption, styleInheritance)
     }
   }
 }

--- a/src/main/scala/com/norbitltd/spoiwo/model/Row.scala
+++ b/src/main/scala/com/norbitltd/spoiwo/model/Row.scala
@@ -1,6 +1,7 @@
 package com.norbitltd.spoiwo.model
 
 import java.util.{Calendar, Date}
+import java.time.{LocalDate => JLocalDate, LocalDateTime => JLocalDateTime}
 import org.joda.time.{DateTime, LocalDate}
 
 object Row {
@@ -56,16 +57,20 @@ case class Row private(cells: Iterable[Cell],
 
   def withCellValues(cellValues: List[Any]): Row = {
     val cells = cellValues.map {
-      case stringValue: String => Cell(stringValue)
-      case doubleValue: Double => Cell(doubleValue)
-      case intValue: Int => Cell(intValue.toDouble)
-      case longValue: Long => Cell(longValue.toDouble)
-      case booleanValue: Boolean => Cell(booleanValue)
-      case dateValue: Date => Cell(dateValue)
-      case dateValue: LocalDate => Cell(dateValue)
-      case dateValue: DateTime => Cell(dateValue)
-      case calendarValue: Calendar => Cell(calendarValue)
-      case value => throw new UnsupportedOperationException("Unable to construct cell from " + value.getClass + " type value!")
+      case stringValue: String           => Cell(stringValue)
+      case doubleValue: Double           => Cell(doubleValue)
+      case decimalValue: BigDecimal      => Cell(decimalValue)
+      case intValue: Int                 => Cell(intValue)
+      case longValue: Long               => Cell(longValue)
+      case booleanValue: Boolean         => Cell(booleanValue)
+      case dateValue: Date               => Cell(dateValue)
+      case dateValue: LocalDate          => Cell(dateValue)
+      case dateValue: DateTime           => Cell(dateValue)
+      case dateValue: JLocalDate         => Cell(dateValue)
+      case dateTimeValue: JLocalDateTime => Cell(dateTimeValue)
+      case calendarValue: Calendar       => Cell(calendarValue)
+      case value                         =>
+        throw new UnsupportedOperationException("Unable to construct cell from " + value.getClass + " type value!")
     }
     copy(cells = cells.toVector)
   }

--- a/src/main/scala/com/norbitltd/spoiwo/utils/JavaTimeApiConversions.scala
+++ b/src/main/scala/com/norbitltd/spoiwo/utils/JavaTimeApiConversions.scala
@@ -1,0 +1,20 @@
+package com.norbitltd.spoiwo.utils
+
+import java.util.Date
+import java.time.{ZoneId, LocalDate => JLocalDate, LocalDateTime => JLocalDateTime}
+import org.joda.time.{DateTime, LocalDate}
+
+object JavaTimeApiConversions {
+
+  implicit class RichJavaLocalDate(ld: JLocalDate) {
+    def toDate: Date = new LocalDate(
+      ld.getYear, ld.getMonthValue, ld.getDayOfMonth
+    ).toDate
+  }
+
+  implicit class RichLocalDateTime(ldt: JLocalDateTime) {
+    def toDate: Date = new DateTime(
+      ldt.atZone(ZoneId.systemDefault()).toInstant.toEpochMilli
+    ).toDate
+  }
+}

--- a/src/test/scala/com/norbitltd/spoiwo/natures/xlsx/Model2XlsxConversionsForCellSpec.scala
+++ b/src/test/scala/com/norbitltd/spoiwo/natures/xlsx/Model2XlsxConversionsForCellSpec.scala
@@ -1,13 +1,13 @@
 package com.norbitltd.spoiwo.natures.xlsx
 
 import java.util.Calendar
-
+import java.time.{LocalDate => JLocalDate, LocalDateTime => JLocalDateTime}
 import com.norbitltd.spoiwo.model.Height._
 import com.norbitltd.spoiwo.model._
 import com.norbitltd.spoiwo.natures.xlsx.Model2XlsxConversions.{convertCell, _}
 import org.apache.poi.ss.usermodel
 import org.apache.poi.xssf.usermodel.{XSSFCell, XSSFWorkbook}
-import org.joda.time.LocalDate
+import org.joda.time.{DateTime, LocalDate}
 import org.scalatest.FlatSpec
 import scala.language.postfixOps
 
@@ -88,6 +88,13 @@ class Model2XlsxConversionsForCellSpec extends FlatSpec {
     assert(xlsx.getNumericCellValue == 90.45)
   }
 
+  it should "return numeric cell when set up with big decimal value" in {
+    val model = Cell(BigDecimal(90.45))
+    val xlsx = convert(model)
+    assert(xlsx.getCellType == usermodel.Cell.CELL_TYPE_NUMERIC)
+    assert(xlsx.getNumericCellValue == 90.45)
+  }
+
   it should "return numeric cell when set up with int value" in {
     val model = Cell(90)
     val xlsx = convert(model)
@@ -139,6 +146,42 @@ class Model2XlsxConversionsForCellSpec extends FlatSpec {
     assert(date.getYear == 2011)
     assert(date.getMonthOfYear == 12)
     assert(date.getDayOfMonth == 13)
+  }
+
+  it should "return numeric cell when set up with java.time.LocalDate value" in {
+    test(JLocalDate.of(2011, 6, 13))
+    test(JLocalDate.of(2011, 11, 13))
+
+    def test(ld: JLocalDate): Unit = {
+      val model = Cell(ld)
+      val xlsx = convert(model)
+
+      val date = new DateTime(xlsx.getDateCellValue)
+      assert(date.getYear           == ld.getYear)
+      assert(date.getMonthOfYear    == ld.getMonthValue)
+      assert(date.getDayOfMonth     == ld.getDayOfMonth)
+      assert(date.getHourOfDay      == 0)
+      assert(date.getMinuteOfHour   == 0)
+      assert(date.getSecondOfMinute == 0)
+    }
+  }
+
+  it should "return numeric cell when set up with java.time.LocalDateTime value" in {
+    test(JLocalDateTime.of(2011,  6, 13, 15, 30, 10))
+    test(JLocalDateTime.of(2011, 11, 13, 15, 30, 10))
+
+    def test(ldt: JLocalDateTime): Unit = {
+      val model = Cell(ldt)
+      val xlsx = convert(model)
+
+      val date = new DateTime(xlsx.getDateCellValue)
+      assert(date.getYear           == ldt.getYear)
+      assert(date.getMonthOfYear    == ldt.getMonthValue)
+      assert(date.getDayOfMonth     == ldt.getDayOfMonth)
+      assert(date.getHourOfDay      == ldt.getHour)
+      assert(date.getMinuteOfHour   == ldt.getMinute)
+      assert(date.getSecondOfMinute == ldt.getSecond)
+    }
   }
 
   it should "return string cell with the date formatted yyyy-MM-dd if date before 1904" in {

--- a/src/test/scala/com/norbitltd/spoiwo/utils/JavaTimeApiConversionsSpec.scala
+++ b/src/test/scala/com/norbitltd/spoiwo/utils/JavaTimeApiConversionsSpec.scala
@@ -1,0 +1,29 @@
+package com.norbitltd.spoiwo.utils
+
+import java.time.{ LocalDate => JLocalDate, LocalDateTime => JLocalDateTime}
+import org.scalatest.FlatSpec
+import org.joda.time.{DateTime, LocalDate}
+import JavaTimeApiConversions._
+
+class JavaTimeApiConversionsSpec extends FlatSpec {
+
+  "Conversion from Java LocalDate to Date" should "produce same Date as from corresponding Joda LocalDate" in {
+
+    test(JLocalDate.of(2011, 6, 13), new LocalDate(2011, 6, 13))
+    test(JLocalDate.of(2011, 11, 13), new LocalDate(2011, 11, 13))
+
+    def test(jld: JLocalDate, ld: LocalDate): Unit = {
+      assert(jld.toDate === ld.toDate)
+    }
+  }
+
+  "Conversion from Java LocalDateTime to Date" should "produce same Date as from corresponding Joda DateTime" in {
+
+    test(JLocalDateTime.of(2011, 6, 13, 15, 30, 10, 5000000), new DateTime(2011, 6, 13, 15, 30, 10, 5))
+    test(JLocalDateTime.of(2011, 11, 13, 15, 30, 10, 999999999), new DateTime(2011, 11, 13, 15, 30, 10, 999))
+
+    def test(jldt: JLocalDateTime, ld: DateTime): Unit = {
+      assert(jldt.toDate === ld.toDate)
+    }
+  }
+}


### PR DESCRIPTION
- make `Cell`s smart constructor accept `LocalDate` and `LocalDateTime`
  from Java 8 Time API.

- make `Cell`s smart constructor accept `BigDecimal` for convenience.

- make `Row`s `withCellValues` accept `LocalDate`, `LocalDateTime` and
  `BigDecimal