### PR TITLE
 Write workbook to a generic OutputStream

### DIFF
--- a/examples/src/main/scala/com/norbitltd/spoiwo/examples/quickguide/SpoiwoExamples.scala
+++ b/examples/src/main/scala/com/norbitltd/spoiwo/examples/quickguide/SpoiwoExamples.scala
@@ -1,11 +1,13 @@
 package com.norbitltd.spoiwo.examples.quickguide
 
+import java.io.FileOutputStream
+
 import com.norbitltd.spoiwo.model.Height._
 import com.norbitltd.spoiwo.natures.xlsx.Model2XlsxConversions._
 import com.norbitltd.spoiwo.model._
 import java.util.{Calendar, Date}
 
-import com.norbitltd.spoiwo.model.enums.{CellVerticalAlignment => VA, CellHorizontalAlignment => HA, CellBorderStyle, Pane, CellFill}
+import com.norbitltd.spoiwo.model.enums.{CellBorderStyle, CellFill, Pane, CellHorizontalAlignment => HA, CellVerticalAlignment => VA}
 import org.apache.poi.ss.util.WorkbookUtil
 
 //noinspection TypeAnnotation
@@ -18,6 +20,12 @@ class SpoiwoExamples {
     Sheet(name = "second sheet"),
     Sheet(name = WorkbookUtil.createSafeSheetName("[O'Brien's sales*?]"))
   ).saveAsXlsx("workbook.xlsx")
+
+  def newSheetSavedWithOutputStream() = Workbook(
+    Sheet(name = "new sheet"),
+    Sheet(name = "second sheet"),
+    Sheet(name = WorkbookUtil.createSafeSheetName("[O'Brien's sales*?]"))
+  ).writeToOutputStream(new FileOutputStream("workbook.xlsx"))
 
 
   def creatingCells() = Sheet(name = "new sheet",

--- a/src/test/scala/com/norbitltd/spoiwo/natures/xlsx/ExportWorkbookSpec.scala
+++ b/src/test/scala/com/norbitltd/spoiwo/natures/xlsx/ExportWorkbookSpec.scala
@@ -1,0 +1,18 @@
+package com.norbitltd.spoiwo.natures.xlsx
+
+import java.io.ByteArrayOutputStream
+import com.norbitltd.spoiwo.model._
+import com.norbitltd.spoiwo.natures.xlsx.Model2XlsxConversions._
+import org.scalatest.{FlatSpec, Matchers}
+
+class ExportWorkbookSpec extends FlatSpec with Matchers {
+
+  private val workbook = Workbook(Sheet(name = "Test Sheet", rows = List.empty))
+
+  "Writing workbook to an output stream" should "write non empty content" in {
+    val baos = new ByteArrayOutputStream()
+    workbook.writeToOutputStream(baos)
+    baos.size() should be > 0
+  }
+
+}

--- a/src/test/scala/com/norbitltd/spoiwo/natures/xlsx/Model2XlsxConversionsForWorkbookCacheSpec.scala
+++ b/src/test/scala/com/norbitltd/spoiwo/natures/xlsx/Model2XlsxConversionsForWorkbookCacheSpec.scala
@@ -7,7 +7,6 @@ import com.norbitltd.spoiwo.model._
 import com.norbitltd.spoiwo.natures.xlsx.Model2XlsxConversions._
 import org.apache.poi.xssf.usermodel.XSSFWorkbook
 import org.scalatest.{FlatSpec, Matchers}
-
 import scala.language.postfixOps
 
 class Model2XlsxConversionsForWorkbookCacheSpec extends FlatSpec with Matchers {


### PR DESCRIPTION
Add possibility to easily write a workbook to a generic OutputStream and use this function internally when saving xlsx to a file