### PR TITLE
Feature/sxssf partial implementation

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -56,7 +56,7 @@ lazy val spoiwo = (project in file("."))
   .settings(commonSettings : _*)
   .settings(
     name := "spoiwo",
-    version := "1.4.1"
+    version := "1.4.2"
   )
 
 lazy val examples = (project in file("examples"))
@@ -64,5 +64,5 @@ lazy val examples = (project in file("examples"))
   .settings(commonSettings : _*)
   .settings(
     name := "spoiwo-examples",
-    version := "1.4.1"
+    version := "1.4.2"
   )

--- a/src/main/scala/com/norbitltd/spoiwo/natures/streaming/xlsx/Model2XlsxConversions.scala
+++ b/src/main/scala/com/norbitltd/spoiwo/natures/streaming/xlsx/Model2XlsxConversions.scala
@@ -1,66 +1,25 @@
 package com.norbitltd.spoiwo.natures.streaming.xlsx
 
 import java.io.{FileOutputStream, OutputStream}
-import java.util.{Calendar, Date}
 
 import com.norbitltd.spoiwo.model.enums._
-import com.norbitltd.spoiwo.model.{BooleanCell, CalendarCell, DateCell, FormulaCell, NoSplitOrFreeze, NumericCell, SplitPane, StringCell, _}
+import com.norbitltd.spoiwo.model.{BooleanCell, CalendarCell, DateCell, FormulaCell, NumericCell, StringCell, _}
+import com.norbitltd.spoiwo.natures.xlsx.BaseXlsx
 import com.norbitltd.spoiwo.natures.xlsx.Model2XlsxEnumConversions._
-import org.apache.poi.common.usermodel.HyperlinkType
 import org.apache.poi.ss.usermodel
 import org.apache.poi.ss.usermodel.{BorderStyle, CellType, FillPatternType, HorizontalAlignment, VerticalAlignment}
-import org.apache.poi.ss.util.{CellAddress, CellRangeAddress}
 import org.apache.poi.xssf.streaming.{SXSSFCell, SXSSFRow, SXSSFSheet, SXSSFWorkbook}
 import org.apache.poi.xssf.usermodel._
-import org.joda.time.{LocalDate, LocalDateTime}
-import org.openxmlformats.schemas.spreadsheetml.x2006.main.{CTTable, CTTableColumns, CTTableStyleInfo}
 
-object Model2XlsxConversions {
+object Model2XlsxConversions extends BaseXlsx {
 
   private type Cache[K, V] = collection.mutable.Map[SXSSFWorkbook, collection.mutable.Map[K, V]]
   private lazy val cellStyleCache = Cache[CellStyle, XSSFCellStyle]()
   private lazy val dataFormatCache = collection.mutable.Map[SXSSFWorkbook, XSSFDataFormat]()
   private lazy val fontCache = Cache[Font, XSSFFont]()
-  private val FirstSupportedDate = new LocalDate(1904, 1, 1)
-  private val LastSupportedDate = new LocalDate(9999, 12, 31)
 
   private def Cache[K, V]() = collection.mutable.Map[SXSSFWorkbook, collection.mutable.Map[K, V]]()
 
-  private def convertColor(color: Color): XSSFColor = new XSSFColor(
-    Array[Byte](color.r.toByte, color.g.toByte, color.b.toByte),
-    new DefaultIndexedColorMap()
-  )
-
-  private def mergeStyle(cell: Cell,
-                         rowStyle: Option[CellStyle],
-                         columnStyle: Option[CellStyle],
-                         sheetStyle: Option[CellStyle]): Cell = {
-    cell.styleInheritance match {
-      case CellStyleInheritance.CellOnly =>
-        cell
-      case CellStyleInheritance.CellThenRow =>
-        cell.withDefaultStyle(rowStyle)
-      case CellStyleInheritance.CellThenColumn =>
-        cell.withDefaultStyle(columnStyle)
-      case CellStyleInheritance.CellThenSheet =>
-        cell.withDefaultStyle(sheetStyle)
-      case CellStyleInheritance.CellThenColumnThenRow =>
-        cell.withDefaultStyle(columnStyle).withDefaultStyle(rowStyle)
-      case CellStyleInheritance.CellThenRowThenColumn =>
-        cell.withDefaultStyle(rowStyle).withDefaultStyle(columnStyle)
-      case CellStyleInheritance.CellThenRowThenSheet =>
-        cell.withDefaultStyle(rowStyle).withDefaultStyle(sheetStyle)
-      case CellStyleInheritance.CellThenColumnThenSheet =>
-        cell.withDefaultStyle(columnStyle).withDefaultStyle(sheetStyle)
-      case CellStyleInheritance.CellThenColumnThenRowThenSheet =>
-        cell.withDefaultStyle(columnStyle).withDefaultStyle(rowStyle).withDefaultStyle(sheetStyle)
-      case CellStyleInheritance.CellThenRowThenColumnThenSheet =>
-        cell.withDefaultStyle(rowStyle).withDefaultStyle(columnStyle).withDefaultStyle(sheetStyle)
-      case unexpected =>
-        throw new IllegalArgumentException(
-          s"Unable to convert CellStyleInheritance=$unexpected to XLSX - unsupported enum!")
-    }
-  }
 
   private[xlsx] def convertCell(modelSheet: Sheet,
                                 modelColumns: Map[Int, Column],
@@ -74,7 +33,8 @@ object Model2XlsxConversions {
     }
 
     val cellWithStyle = mergeStyle(c, modelRow.style, modelColumns.get(cellNumber).flatMap(_.style), modelSheet.style)
-    cellWithStyle.style.foreach(s => cell.setCellStyle(convertCellStyle(s, cell.getRow.getSheet.getWorkbook.asInstanceOf[SXSSFWorkbook])))
+    cellWithStyle.style.foreach(s =>
+      cell.setCellStyle(convertCellStyle(s, cell.getRow.getSheet.getWorkbook.asInstanceOf[SXSSFWorkbook])))
 
     c match {
       case BlankCell(_, _, _)               => cell.setCellValue(null: String)
@@ -89,55 +49,13 @@ object Model2XlsxConversions {
     cell
   }
 
-  private def setDateCell(c: Cell, cell: SXSSFCell, value: Date) {
-    val dateStyle = c.format.getOrElse("yyyy-MM-dd")
-    val dateTime = LocalDateTime.fromDateFields(value)
-    val date = dateTime.toLocalDate
-    if (date.isBefore(FirstSupportedDate) || date.isAfter(LastSupportedDate)) {
-      cell.setCellValue(dateTime.toString(dateStyle))
-    } else {
-      cell.setCellValue(value)
-    }
-  }
-
-  private def setCalendarCell(c: Cell, cell: SXSSFCell, value: Calendar) {
-    val dateStyle = c.format.getOrElse("yyyy-MM-dd")
-    val dateTime = LocalDateTime.fromCalendarFields(value)
-    val date = dateTime.toLocalDate
-    if (date.isBefore(FirstSupportedDate) || date.isAfter(LastSupportedDate)) {
-      cell.setCellValue(dateTime.toString(dateStyle))
-    } else {
-      cell.setCellValue(value)
-    }
-  }
-  private def setHyperLinkUrlCell(cell: SXSSFCell, value: HyperLinkUrl, row: SXSSFRow) {
-    val link = row.getSheet.getWorkbook.getCreationHelper.createHyperlink(HyperlinkType.URL)
-    link.setAddress(value.address)
-    cell.setCellValue(value.text)
-    cell.setHyperlink(link)
-
-  }
-  private[xlsx] def convertCellBorders(borders: CellBorders, style: XSSFCellStyle) {
-    borders.leftStyle.foreach(s => style.setBorderLeft(convertBorderStyle(s)))
-    borders.leftColor.foreach(c => style.setLeftBorderColor(convertColor(c)))
-    borders.bottomStyle.foreach(s => style.setBorderBottom(convertBorderStyle(s)))
-    borders.bottomColor.foreach(c => style.setBottomBorderColor(convertColor(c)))
-    borders.rightStyle.foreach(s => style.setBorderRight(convertBorderStyle(s)))
-    borders.rightColor.foreach(c => style.setRightBorderColor(convertColor(c)))
-    borders.topStyle.foreach(s => style.setBorderTop(convertBorderStyle(s)))
-    borders.topColor.foreach(c => style.setTopBorderColor(convertColor(c)))
-  }
-
-  private def convertCellDataFormat(cdf: CellDataFormat, workbook: SXSSFWorkbook, cellStyle: XSSFCellStyle) {
+  private def convertCellDataFormat(cdf: CellDataFormat, workbook: SXSSFWorkbook, cellStyle: usermodel.CellStyle) {
     cdf.formatString.foreach(formatString => {
       val format = dataFormatCache.getOrElseUpdate(workbook, workbook.getXSSFWorkbook.createDataFormat())
       val formatIndex = format.getFormat(formatString)
       cellStyle.setDataFormat(formatIndex)
     })
   }
-
-  private def convertCellRange(cr: CellRange): CellRangeAddress =
-    new org.apache.poi.ss.util.CellRangeAddress(cr.rowRange._1, cr.rowRange._2, cr.columnRange._1, cr.columnRange._2)
 
   private[xlsx] def convertCellStyle(cs: CellStyle, workbook: SXSSFWorkbook): XSSFCellStyle =
     getCachedOrUpdate(cellStyleCache, cs, workbook) {
@@ -160,103 +78,22 @@ object Model2XlsxConversions {
       cellStyle
     }
 
-  private[xlsx] def convertColumn(c: Column, sheet: SXSSFSheet) {
-    val i = c.index.getOrElse(
-      throw new IllegalArgumentException(
-        "Undefined column index! " +
-          "Something went terribly wrong as it should have been derived if not specified explicitly!"))
-
-    c.autoSized.foreach(as => if (as) sheet.autoSizeColumn(i))
-    c.break.foreach(b => if (b) sheet.setColumnBreak(i))
-    c.groupCollapsed.foreach(gc => sheet.setColumnGroupCollapsed(i, gc))
-    c.hidden.foreach(h => sheet.setColumnHidden(i, h))
-    c.width.foreach(w => sheet.setColumnWidth(i, w.toUnits))
-  }
-
-  private def convertColumnRange(cr: ColumnRange) =
-    CellRangeAddress.valueOf("%s:%s".format(cr.firstColumnName, cr.lastColumnName))
-
   private def convertFooter(f: Footer, sheet: SXSSFSheet) {
     f.left.foreach(sheet.getFooter.setLeft)
     f.center.foreach(sheet.getFooter.setCenter)
     f.right.foreach(sheet.getFooter.setRight)
-
-    /*f.firstLeft.foreach(sheet.getFirstFooter.setLeft)
-    f.firstCenter.foreach(sheet.getSheetTypeHeaderFooter.setCenter)
-    f.firstRight.foreach(sheet.getFirstFooter.setRight)*/
-
-    //Oddfooter = getFooter
-    f.oddLeft.foreach(sheet.getFooter.setLeft)
-    f.oddCenter.foreach(sheet.getFooter.setCenter)
-    f.oddRight.foreach(sheet.getFooter.setRight)
-
-/*    f.evenLeft.foreach(sheet.getEvenFooter.setLeft)
-    f.evenCenter.foreach(sheet.getEvenFooter.setCenter)
-    f.evenRight.foreach(sheet.getEvenFooter.setRight)*/
   }
 
   private[xlsx] def convertFont(f: Font, workbook: SXSSFWorkbook): XSSFFont =
     getCachedOrUpdate(fontCache, f, workbook) {
       val font = workbook.getXSSFWorkbook.createFont()
-      f.bold.foreach(font.setBold)
-      f.charSet.foreach(charSet => font.setCharSet(convertCharset(charSet).getNativeId))
-      f.color.foreach(c => font.setColor(convertColor(c)))
-      f.family.foreach(family => font.setFamily(convertFontFamily(family)))
-      f.height.foreach(height => font.setFontHeightInPoints(height.toPoints))
-      f.italic.foreach(font.setItalic)
-      f.scheme.foreach(scheme => font.setScheme(convertFontScheme(scheme)))
-      f.fontName.foreach(font.setFontName)
-      f.strikeout.foreach(font.setStrikeout)
-      f.typeOffset.foreach(offset => font.setTypeOffset(convertTypeOffset(offset)))
-      f.underline.foreach(underline => font.setUnderline(convertUnderline(underline)))
-      font
+      convertFont(f, font)
     }
 
   private def convertHeader(h: Header, sheet: SXSSFSheet) {
     h.left.foreach(sheet.getHeader.setLeft)
     h.center.foreach(sheet.getHeader.setCenter)
     h.right.foreach(sheet.getHeader.setRight)
-/*
-    h.firstLeft.foreach(sheet.getFirstHeader.setLeft)
-    h.firstCenter.foreach(sheet.getFirstHeader.setCenter)
-    h.firstRight.foreach(sheet.getFirstHeader.setRight)*/
-
-    h.oddLeft.foreach(sheet.getHeader.setLeft)
-    h.oddCenter.foreach(sheet.getHeader.setCenter)
-    h.oddRight.foreach(sheet.getHeader.setRight)
-
-/*    h.evenLeft.foreach(sheet.getEvenHeader.setLeft)
-    h.evenCenter.foreach(sheet.getEvenHeader.setCenter)
-    h.evenRight.foreach(sheet.getEvenHeader.setRight)*/
-  }
-
-  private def convertMargins(margins: Margins, sheet: SXSSFSheet) {
-    margins.top.foreach(topMargin => sheet.setMargin(usermodel.Sheet.TopMargin, topMargin))
-    margins.bottom.foreach(bottomMargin => sheet.setMargin(usermodel.Sheet.BottomMargin, bottomMargin))
-    margins.right.foreach(rightMargin => sheet.setMargin(usermodel.Sheet.RightMargin, rightMargin))
-    margins.left.foreach(leftMargin => sheet.setMargin(usermodel.Sheet.LeftMargin, leftMargin))
-    margins.header.foreach(headerMargin => sheet.setMargin(usermodel.Sheet.HeaderMargin, headerMargin))
-    margins.footer.foreach(footerMargin => sheet.setMargin(usermodel.Sheet.FooterMargin, footerMargin))
-  }
-
-  private def convertPane(pane: Pane): Int = pane match {
-    case Pane.LowerLeftPane  => org.apache.poi.ss.usermodel.Sheet.PANE_LOWER_LEFT
-    case Pane.LowerRightPane => org.apache.poi.ss.usermodel.Sheet.PANE_LOWER_RIGHT
-    case Pane.UpperLeftPane  => org.apache.poi.ss.usermodel.Sheet.PANE_UPPER_LEFT
-    case Pane.UpperRightPane => org.apache.poi.ss.usermodel.Sheet.PANE_UPPER_RIGHT
-    case unexpected =>
-      throw new IllegalArgumentException(s"Unable to convert Pane=$unexpected to XLSX - unsupported enum!")
-  }
-
-  private def convertPaneAction(paneAction: PaneAction, sheet: SXSSFSheet) {
-    paneAction match {
-      case NoSplitOrFreeze() =>
-        sheet.createFreezePane(0, 0)
-      case FreezePane(columnSplit, rowSplit, leftMostColumn, topRow) =>
-        sheet.createFreezePane(columnSplit, rowSplit, leftMostColumn, topRow)
-      case SplitPane(xSplitPosition, ySplitPosition, leftMostColumn, topRow, activePane) =>
-        sheet.createSplitPane(xSplitPosition, ySplitPosition, leftMostColumn, topRow, convertPane(activePane))
-    }
   }
 
   private[xlsx] def convertRow(modelColumns: Map[Int, Column],
@@ -271,18 +108,6 @@ object Model2XlsxConversions {
     modelRow.hidden.foreach(row.setZeroHeight)
     modelRow.cells.foreach(cell => convertCell(modelSheet, modelColumns, modelRow, cell, row))
     row
-  }
-
-  private def validateCells(r: Row) {
-    val indexedCells = r.cells.filter(_.index.isDefined)
-    val contextCells = r.cells.filter(_.index.isEmpty)
-
-    if (indexedCells.nonEmpty && contextCells.nonEmpty)
-      throw new IllegalArgumentException("It is not allowed to mix cells with and without index within a single row!")
-
-    val distinctIndexes = indexedCells.map(_.index).toSet.flatten
-    if (indexedCells.size != distinctIndexes.size)
-      throw new IllegalArgumentException("It is not allowed to have cells with duplicate index within a single row!")
   }
 
   private[xlsx] def convertSheet(s: Sheet, workbook: SXSSFWorkbook): SXSSFSheet = {
@@ -309,156 +134,25 @@ object Model2XlsxConversions {
     s.repeatingColumns.foreach(rc => sheet.setRepeatingColumns(convertColumnRange(rc)))
     s.password.foreach(ps => sheet.protectSheet(ps))
 
-    if(!s.tables.isEmpty) {
-      throw  new IllegalStateException("createTable is not supported by SXSSF right now")
-    }
-
     sheet
   }
-  private def validateRows(s: Sheet) {
-    val indexedRows = s.rows.filter(_.index.isDefined)
-    val contextRows = s.rows.filter(_.index.isEmpty)
 
-    if (indexedRows.nonEmpty && contextRows.nonEmpty) {
-      throw new IllegalArgumentException("It is not allowed to mix rows with and without index within a single sheet!")
-    }
-
-    val distinctIndexes = indexedRows.flatMap(_.index).toSet
-    if (indexedRows.size != distinctIndexes.size)
-      throw new IllegalArgumentException("It is not allowed to have rows with duplicate index within a single sheet!")
+  override def setTabColor(sheet: usermodel.Sheet, color: XSSFColor) {
+    sheet.asInstanceOf[SXSSFSheet].setTabColor(color)
   }
 
-  private def updateColumnsWithIndexes(s: Sheet): List[Column] = {
-    val currentColumnIndexes = s.columns.flatMap(_.index).toSet
-    if (currentColumnIndexes.isEmpty) {
-      s.columns.zipWithIndex.map {
-        case (column, index) => column.withIndex(index)
-      }
-    } else if (currentColumnIndexes.size == s.columns.size) {
-      s.columns
-    } else {
-      throw new IllegalArgumentException(
-        "When explicitly specifying column index you are required to provide it " +
-          "uniquely for all columns in this sheet definition!")
-    }
-  }
-
-  private[xlsx] def convertSheetProperties(sp: SheetProperties, sheet: SXSSFSheet) {
-    sp.autoFilter.foreach(autoFilterRange => sheet.setAutoFilter(convertCellRange(autoFilterRange)))
-    sp.activeCell.foreach(stringReference => sheet.setActiveCell(new CellAddress(stringReference)))
-    sp.autoBreaks.foreach(sheet.setAutobreaks)
-    sp.defaultColumnWidth.foreach(sheet.setDefaultColumnWidth)
-    sp.defaultRowHeight.foreach(height => sheet.setDefaultRowHeightInPoints(height.toPoints))
-    sp.displayFormulas.foreach(sheet.setDisplayFormulas)
-    sp.displayGridLines.foreach(sheet.setDisplayGridlines)
-    sp.displayGuts.foreach(sheet.setDisplayGuts)
-    sp.displayRowColHeadings.foreach(sheet.setDisplayRowColHeadings)
-    sp.displayZeros.foreach(sheet.setDisplayZeros)
-    sp.fitToPage.foreach(sheet.setFitToPage)
-    sp.forceFormulaRecalculation.foreach(sheet.setForceFormulaRecalculation)
-    sp.horizontallyCenter.foreach(sheet.setHorizontallyCenter)
-    sp.printArea.foreach {
-      case CellRange((startRow, endRow), (startColumn, endColumn)) =>
-        val workbook = sheet.getWorkbook
-        val sheetIndex = workbook.getNumberOfSheets - 1
-        workbook.setPrintArea(sheetIndex, startColumn, endColumn, startRow, endRow)
-    }
-    sp.printGridLines.foreach(sheet.setPrintGridlines)
-    sp.rightToLeft.foreach(sheet.setRightToLeft)
-    sp.rowSumsBelow.foreach(sheet.setRowSumsBelow)
-    sp.rowSumsRight.foreach(sheet.setRowSumsRight)
-    sp.selected.foreach(sheet.setSelected)
-    sp.tabColor.foreach(c => sheet.setTabColor(convertColor(c)))
-    sp.virtuallyCenter.foreach(sheet.setVerticallyCenter)
-    sp.zoom.foreach(sheet.setZoom)
-  }
-
-  private def convertPrintSetup(printSetup: PrintSetup, sheet: SXSSFSheet) {
+  override def additionalPrintSetup(printSetup: PrintSetup, sheetPs: usermodel.PrintSetup) {
     if (printSetup != PrintSetup.Default) {
-      val ps = sheet.getPrintSetup.asInstanceOf[XSSFPrintSetup]
-      printSetup.copies.foreach(ps.setCopies)
-      printSetup.draft.foreach(ps.setDraft)
-      printSetup.fitHeight.foreach(ps.setFitHeight)
-      printSetup.fitWidth.foreach(ps.setFitWidth)
-      printSetup.footerMargin.foreach(ps.setFooterMargin)
-      printSetup.headerMargin.foreach(ps.setHeaderMargin)
-      printSetup.hResolution.foreach(ps.setHResolution)
-      printSetup.landscape.foreach(ps.setLandscape)
-      printSetup.leftToRight.foreach(ps.setLeftToRight)
-      printSetup.noColor.foreach(ps.setNoColor)
-      printSetup.noOrientation.foreach(ps.setNoOrientation)
+      val ps = sheetPs.asInstanceOf[XSSFPrintSetup]
       printSetup.pageOrder.foreach(po => ps.setPageOrder(convertPageOrder(po)))
-      printSetup.pageStart.foreach(ps.setPageStart)
       printSetup.paperSize.foreach(px => ps.setPaperSize(convertPaperSize(px)))
-      printSetup.scale.foreach(ps.setScale)
-      printSetup.usePage.foreach(ps.setUsePage)
-      printSetup.validSettings.foreach(ps.setValidSettings)
-      printSetup.vResolution.foreach(ps.setVResolution)
     }
   }
-
-  private def convertRowRange(rr: RowRange) =
-    CellRangeAddress.valueOf("%d:%d".format(rr.firstRowIndex, rr.lastRowIndex))
 
   private[xlsx] def validateTables(modelSheet: Sheet): Unit = {
-    val ids = modelSheet.tables.flatMap(_.id)
-    if (ids.size != ids.toSet.size)
-      throw new IllegalArgumentException("Specified table ids need to be unique.")
-  }
-
-  private[xlsx] def validateTableColumns(modelTable: Table): Unit = {
-
-    def insufficientColumnsDefined = {
-      val (sCol, eCol) = modelTable.cellRange.columnRange
-      val neededColumns = (eCol - sCol) + 1
-      val definedColumns = modelTable.columns.size
-      neededColumns != definedColumns
+    if (!modelSheet.tables.isEmpty) {
+      throw new IllegalStateException("createTable is not supported by SXSSF right now")
     }
-
-    if (modelTable.columns.nonEmpty && insufficientColumnsDefined) {
-      throw new IllegalArgumentException(
-        "When explicitly specifying table columns you are required to provide as many " +
-          "columns as in the cell range."
-      )
-    }
-  }
-
-  private[xlsx] def convertTableColumns(modelTable: Table, ctTable: CTTable): CTTableColumns = {
-
-    def generateColumns = {
-      val (sCol, eCol) = modelTable.cellRange.columnRange
-      val neededColumns = (eCol - sCol) + 1
-      (0 until neededColumns) map { index ⇒
-        val columnId = index + 1
-        TableColumn(
-          name = s"TableColumn$columnId",
-          id = columnId.toLong
-        )
-      }
-    }
-
-    val modelColumns = if (modelTable.columns.nonEmpty) modelTable.columns else generateColumns
-    val columns = ctTable.addNewTableColumns()
-    columns.setCount(modelColumns.size)
-    modelColumns.foreach { mc ⇒
-      val column = columns.addNewTableColumn()
-      column.setName(mc.name)
-      column.setId(mc.id)
-    }
-    columns
-  }
-
-  private[xlsx] def convertTableStyle(modelTableStyle: TableStyle, ctTable: CTTable): CTTableStyleInfo = {
-    val style = ctTable.addNewTableStyleInfo()
-    style.setName(modelTableStyle.name.value)
-    modelTableStyle.showColumnStripes.foreach(style.setShowColumnStripes)
-    modelTableStyle.showRowStripes.foreach(style.setShowRowStripes)
-    style
-  }
-
-  private[xlsx] def setTableReference(modelTable: Table, ctTable: CTTable): Unit = {
-    val cellRangeAddress = convertCellRange(modelTable.cellRange)
-    ctTable.setRef(cellRangeAddress.formatAsString())
   }
 
   private[xlsx] def convertWorkbook(wb: Workbook): SXSSFWorkbook = {

--- a/src/main/scala/com/norbitltd/spoiwo/natures/streaming/xlsx/Model2XlsxConversions.scala
+++ b/src/main/scala/com/norbitltd/spoiwo/natures/streaming/xlsx/Model2XlsxConversions.scala
@@ -1,0 +1,581 @@
+package com.norbitltd.spoiwo.natures.streaming.xlsx
+
+import java.io.{FileOutputStream, OutputStream}
+import java.util.{Calendar, Date}
+
+import com.norbitltd.spoiwo.model.enums._
+import com.norbitltd.spoiwo.model.{BooleanCell, CalendarCell, DateCell, FormulaCell, NoSplitOrFreeze, NumericCell, SplitPane, StringCell, _}
+import com.norbitltd.spoiwo.natures.xlsx.Model2XlsxEnumConversions._
+import org.apache.poi.common.usermodel.HyperlinkType
+import org.apache.poi.ss.usermodel
+import org.apache.poi.ss.usermodel.{BorderStyle, CellType, FillPatternType, HorizontalAlignment, VerticalAlignment}
+import org.apache.poi.ss.util.{CellAddress, CellRangeAddress}
+import org.apache.poi.xssf.streaming.{SXSSFCell, SXSSFRow, SXSSFSheet, SXSSFWorkbook}
+import org.apache.poi.xssf.usermodel._
+import org.joda.time.{LocalDate, LocalDateTime}
+import org.openxmlformats.schemas.spreadsheetml.x2006.main.{CTTable, CTTableColumns, CTTableStyleInfo}
+
+object Model2XlsxConversions {
+
+  private type Cache[K, V] = collection.mutable.Map[SXSSFWorkbook, collection.mutable.Map[K, V]]
+  private lazy val cellStyleCache = Cache[CellStyle, XSSFCellStyle]()
+  private lazy val dataFormatCache = collection.mutable.Map[SXSSFWorkbook, XSSFDataFormat]()
+  private lazy val fontCache = Cache[Font, XSSFFont]()
+  private val FirstSupportedDate = new LocalDate(1904, 1, 1)
+  private val LastSupportedDate = new LocalDate(9999, 12, 31)
+
+  private def Cache[K, V]() = collection.mutable.Map[SXSSFWorkbook, collection.mutable.Map[K, V]]()
+
+  private def convertColor(color: Color): XSSFColor = new XSSFColor(
+    Array[Byte](color.r.toByte, color.g.toByte, color.b.toByte),
+    new DefaultIndexedColorMap()
+  )
+
+  private def mergeStyle(cell: Cell,
+                         rowStyle: Option[CellStyle],
+                         columnStyle: Option[CellStyle],
+                         sheetStyle: Option[CellStyle]): Cell = {
+    cell.styleInheritance match {
+      case CellStyleInheritance.CellOnly =>
+        cell
+      case CellStyleInheritance.CellThenRow =>
+        cell.withDefaultStyle(rowStyle)
+      case CellStyleInheritance.CellThenColumn =>
+        cell.withDefaultStyle(columnStyle)
+      case CellStyleInheritance.CellThenSheet =>
+        cell.withDefaultStyle(sheetStyle)
+      case CellStyleInheritance.CellThenColumnThenRow =>
+        cell.withDefaultStyle(columnStyle).withDefaultStyle(rowStyle)
+      case CellStyleInheritance.CellThenRowThenColumn =>
+        cell.withDefaultStyle(rowStyle).withDefaultStyle(columnStyle)
+      case CellStyleInheritance.CellThenRowThenSheet =>
+        cell.withDefaultStyle(rowStyle).withDefaultStyle(sheetStyle)
+      case CellStyleInheritance.CellThenColumnThenSheet =>
+        cell.withDefaultStyle(columnStyle).withDefaultStyle(sheetStyle)
+      case CellStyleInheritance.CellThenColumnThenRowThenSheet =>
+        cell.withDefaultStyle(columnStyle).withDefaultStyle(rowStyle).withDefaultStyle(sheetStyle)
+      case CellStyleInheritance.CellThenRowThenColumnThenSheet =>
+        cell.withDefaultStyle(rowStyle).withDefaultStyle(columnStyle).withDefaultStyle(sheetStyle)
+      case unexpected =>
+        throw new IllegalArgumentException(
+          s"Unable to convert CellStyleInheritance=$unexpected to XLSX - unsupported enum!")
+    }
+  }
+
+  private[xlsx] def convertCell(modelSheet: Sheet,
+                                modelColumns: Map[Int, Column],
+                                modelRow: Row,
+                                c: Cell,
+                                row: SXSSFRow): SXSSFCell = {
+    val cellNumber = c.index.getOrElse(if (row.getLastCellNum < 0) 0 else row.getLastCellNum.toInt)
+    val cell = Option(row.getCell(cellNumber)).getOrElse(row.createCell(cellNumber))
+    if (cell.getCellType == CellType.FORMULA) {
+      cell.setCellFormula(null)
+    }
+
+    val cellWithStyle = mergeStyle(c, modelRow.style, modelColumns.get(cellNumber).flatMap(_.style), modelSheet.style)
+    cellWithStyle.style.foreach(s => cell.setCellStyle(convertCellStyle(s, cell.getRow.getSheet.getWorkbook.asInstanceOf[SXSSFWorkbook])))
+
+    c match {
+      case BlankCell(_, _, _)               => cell.setCellValue(null: String)
+      case StringCell(value, _, _, _)       => cell.setCellValue(value)
+      case FormulaCell(formula, _, _, _)    => cell.setCellFormula(formula)
+      case NumericCell(value, _, _, _)      => cell.setCellValue(value)
+      case BooleanCell(value, _, _, _)      => cell.setCellValue(value)
+      case DateCell(value, _, _, _)         => setDateCell(c, cell, value)
+      case CalendarCell(value, _, _, _)     => setCalendarCell(c, cell, value)
+      case HyperLinkUrlCell(value, _, _, _) => setHyperLinkUrlCell(cell, value, row)
+    }
+    cell
+  }
+
+  private def setDateCell(c: Cell, cell: SXSSFCell, value: Date) {
+    val dateStyle = c.format.getOrElse("yyyy-MM-dd")
+    val dateTime = LocalDateTime.fromDateFields(value)
+    val date = dateTime.toLocalDate
+    if (date.isBefore(FirstSupportedDate) || date.isAfter(LastSupportedDate)) {
+      cell.setCellValue(dateTime.toString(dateStyle))
+    } else {
+      cell.setCellValue(value)
+    }
+  }
+
+  private def setCalendarCell(c: Cell, cell: SXSSFCell, value: Calendar) {
+    val dateStyle = c.format.getOrElse("yyyy-MM-dd")
+    val dateTime = LocalDateTime.fromCalendarFields(value)
+    val date = dateTime.toLocalDate
+    if (date.isBefore(FirstSupportedDate) || date.isAfter(LastSupportedDate)) {
+      cell.setCellValue(dateTime.toString(dateStyle))
+    } else {
+      cell.setCellValue(value)
+    }
+  }
+  private def setHyperLinkUrlCell(cell: SXSSFCell, value: HyperLinkUrl, row: SXSSFRow) {
+    val link = row.getSheet.getWorkbook.getCreationHelper.createHyperlink(HyperlinkType.URL)
+    link.setAddress(value.address)
+    cell.setCellValue(value.text)
+    cell.setHyperlink(link)
+
+  }
+  private[xlsx] def convertCellBorders(borders: CellBorders, style: XSSFCellStyle) {
+    borders.leftStyle.foreach(s => style.setBorderLeft(convertBorderStyle(s)))
+    borders.leftColor.foreach(c => style.setLeftBorderColor(convertColor(c)))
+    borders.bottomStyle.foreach(s => style.setBorderBottom(convertBorderStyle(s)))
+    borders.bottomColor.foreach(c => style.setBottomBorderColor(convertColor(c)))
+    borders.rightStyle.foreach(s => style.setBorderRight(convertBorderStyle(s)))
+    borders.rightColor.foreach(c => style.setRightBorderColor(convertColor(c)))
+    borders.topStyle.foreach(s => style.setBorderTop(convertBorderStyle(s)))
+    borders.topColor.foreach(c => style.setTopBorderColor(convertColor(c)))
+  }
+
+  private def convertCellDataFormat(cdf: CellDataFormat, workbook: SXSSFWorkbook, cellStyle: XSSFCellStyle) {
+    cdf.formatString.foreach(formatString => {
+      val format = dataFormatCache.getOrElseUpdate(workbook, workbook.getXSSFWorkbook.createDataFormat())
+      val formatIndex = format.getFormat(formatString)
+      cellStyle.setDataFormat(formatIndex)
+    })
+  }
+
+  private def convertCellRange(cr: CellRange): CellRangeAddress =
+    new org.apache.poi.ss.util.CellRangeAddress(cr.rowRange._1, cr.rowRange._2, cr.columnRange._1, cr.columnRange._2)
+
+  private[xlsx] def convertCellStyle(cs: CellStyle, workbook: SXSSFWorkbook): XSSFCellStyle =
+    getCachedOrUpdate(cellStyleCache, cs, workbook) {
+      val cellStyle = workbook.getXSSFWorkbook.createCellStyle()
+      cs.borders.foreach(b => convertCellBorders(b, cellStyle))
+      cs.dataFormat.foreach(df => convertCellDataFormat(df, workbook, cellStyle))
+      cs.font.foreach(f => cellStyle.setFont(convertFont(f, workbook)))
+      cs.fillPattern.foreach(fp => cellStyle.setFillPattern(convertCellFill(fp)))
+      cs.fillBackgroundColor.foreach(c => cellStyle.setFillBackgroundColor(convertColor(c)))
+      cs.fillForegroundColor.foreach(c => cellStyle.setFillForegroundColor(convertColor(c)))
+
+      cs.horizontalAlignment.foreach(ha => cellStyle.setAlignment(convertHorizontalAlignment(ha)))
+      cs.verticalAlignment.foreach(va => cellStyle.setVerticalAlignment(convertVerticalAlignment(va)))
+
+      cs.hidden.foreach(cellStyle.setHidden)
+      cs.indention.foreach(cellStyle.setIndention)
+      cs.locked.foreach(cellStyle.setLocked)
+      cs.rotation.foreach(cellStyle.setRotation)
+      cs.wrapText.foreach(cellStyle.setWrapText)
+      cellStyle
+    }
+
+  private[xlsx] def convertColumn(c: Column, sheet: SXSSFSheet) {
+    val i = c.index.getOrElse(
+      throw new IllegalArgumentException(
+        "Undefined column index! " +
+          "Something went terribly wrong as it should have been derived if not specified explicitly!"))
+
+    c.autoSized.foreach(as => if (as) sheet.autoSizeColumn(i))
+    c.break.foreach(b => if (b) sheet.setColumnBreak(i))
+    c.groupCollapsed.foreach(gc => sheet.setColumnGroupCollapsed(i, gc))
+    c.hidden.foreach(h => sheet.setColumnHidden(i, h))
+    c.width.foreach(w => sheet.setColumnWidth(i, w.toUnits))
+  }
+
+  private def convertColumnRange(cr: ColumnRange) =
+    CellRangeAddress.valueOf("%s:%s".format(cr.firstColumnName, cr.lastColumnName))
+
+  private def convertFooter(f: Footer, sheet: SXSSFSheet) {
+    f.left.foreach(sheet.getFooter.setLeft)
+    f.center.foreach(sheet.getFooter.setCenter)
+    f.right.foreach(sheet.getFooter.setRight)
+
+    /*f.firstLeft.foreach(sheet.getFirstFooter.setLeft)
+    f.firstCenter.foreach(sheet.getSheetTypeHeaderFooter.setCenter)
+    f.firstRight.foreach(sheet.getFirstFooter.setRight)*/
+
+    //Oddfooter = getFooter
+    f.oddLeft.foreach(sheet.getFooter.setLeft)
+    f.oddCenter.foreach(sheet.getFooter.setCenter)
+    f.oddRight.foreach(sheet.getFooter.setRight)
+
+/*    f.evenLeft.foreach(sheet.getEvenFooter.setLeft)
+    f.evenCenter.foreach(sheet.getEvenFooter.setCenter)
+    f.evenRight.foreach(sheet.getEvenFooter.setRight)*/
+  }
+
+  private[xlsx] def convertFont(f: Font, workbook: SXSSFWorkbook): XSSFFont =
+    getCachedOrUpdate(fontCache, f, workbook) {
+      val font = workbook.getXSSFWorkbook.createFont()
+      f.bold.foreach(font.setBold)
+      f.charSet.foreach(charSet => font.setCharSet(convertCharset(charSet).getNativeId))
+      f.color.foreach(c => font.setColor(convertColor(c)))
+      f.family.foreach(family => font.setFamily(convertFontFamily(family)))
+      f.height.foreach(height => font.setFontHeightInPoints(height.toPoints))
+      f.italic.foreach(font.setItalic)
+      f.scheme.foreach(scheme => font.setScheme(convertFontScheme(scheme)))
+      f.fontName.foreach(font.setFontName)
+      f.strikeout.foreach(font.setStrikeout)
+      f.typeOffset.foreach(offset => font.setTypeOffset(convertTypeOffset(offset)))
+      f.underline.foreach(underline => font.setUnderline(convertUnderline(underline)))
+      font
+    }
+
+  private def convertHeader(h: Header, sheet: SXSSFSheet) {
+    h.left.foreach(sheet.getHeader.setLeft)
+    h.center.foreach(sheet.getHeader.setCenter)
+    h.right.foreach(sheet.getHeader.setRight)
+/*
+    h.firstLeft.foreach(sheet.getFirstHeader.setLeft)
+    h.firstCenter.foreach(sheet.getFirstHeader.setCenter)
+    h.firstRight.foreach(sheet.getFirstHeader.setRight)*/
+
+    h.oddLeft.foreach(sheet.getHeader.setLeft)
+    h.oddCenter.foreach(sheet.getHeader.setCenter)
+    h.oddRight.foreach(sheet.getHeader.setRight)
+
+/*    h.evenLeft.foreach(sheet.getEvenHeader.setLeft)
+    h.evenCenter.foreach(sheet.getEvenHeader.setCenter)
+    h.evenRight.foreach(sheet.getEvenHeader.setRight)*/
+  }
+
+  private def convertMargins(margins: Margins, sheet: SXSSFSheet) {
+    margins.top.foreach(topMargin => sheet.setMargin(usermodel.Sheet.TopMargin, topMargin))
+    margins.bottom.foreach(bottomMargin => sheet.setMargin(usermodel.Sheet.BottomMargin, bottomMargin))
+    margins.right.foreach(rightMargin => sheet.setMargin(usermodel.Sheet.RightMargin, rightMargin))
+    margins.left.foreach(leftMargin => sheet.setMargin(usermodel.Sheet.LeftMargin, leftMargin))
+    margins.header.foreach(headerMargin => sheet.setMargin(usermodel.Sheet.HeaderMargin, headerMargin))
+    margins.footer.foreach(footerMargin => sheet.setMargin(usermodel.Sheet.FooterMargin, footerMargin))
+  }
+
+  private def convertPane(pane: Pane): Int = pane match {
+    case Pane.LowerLeftPane  => org.apache.poi.ss.usermodel.Sheet.PANE_LOWER_LEFT
+    case Pane.LowerRightPane => org.apache.poi.ss.usermodel.Sheet.PANE_LOWER_RIGHT
+    case Pane.UpperLeftPane  => org.apache.poi.ss.usermodel.Sheet.PANE_UPPER_LEFT
+    case Pane.UpperRightPane => org.apache.poi.ss.usermodel.Sheet.PANE_UPPER_RIGHT
+    case unexpected =>
+      throw new IllegalArgumentException(s"Unable to convert Pane=$unexpected to XLSX - unsupported enum!")
+  }
+
+  private def convertPaneAction(paneAction: PaneAction, sheet: SXSSFSheet) {
+    paneAction match {
+      case NoSplitOrFreeze() =>
+        sheet.createFreezePane(0, 0)
+      case FreezePane(columnSplit, rowSplit, leftMostColumn, topRow) =>
+        sheet.createFreezePane(columnSplit, rowSplit, leftMostColumn, topRow)
+      case SplitPane(xSplitPosition, ySplitPosition, leftMostColumn, topRow, activePane) =>
+        sheet.createSplitPane(xSplitPosition, ySplitPosition, leftMostColumn, topRow, convertPane(activePane))
+    }
+  }
+
+  private[xlsx] def convertRow(modelColumns: Map[Int, Column],
+                               modelRow: Row,
+                               modelSheet: Sheet,
+                               sheet: SXSSFSheet): SXSSFRow = {
+    validateCells(modelRow)
+    val indexNumber = modelRow.index.getOrElse(if (sheet.rowIterator().hasNext) sheet.getLastRowNum + 1 else 0)
+    val row = Option(sheet.getRow(indexNumber)).getOrElse(sheet.createRow(indexNumber))
+    modelRow.height.foreach(h => row.setHeightInPoints(h.toPoints))
+    modelRow.style.foreach(s => row.setRowStyle(convertCellStyle(s, row.getSheet.getWorkbook)))
+    modelRow.hidden.foreach(row.setZeroHeight)
+    modelRow.cells.foreach(cell => convertCell(modelSheet, modelColumns, modelRow, cell, row))
+    row
+  }
+
+  private def validateCells(r: Row) {
+    val indexedCells = r.cells.filter(_.index.isDefined)
+    val contextCells = r.cells.filter(_.index.isEmpty)
+
+    if (indexedCells.nonEmpty && contextCells.nonEmpty)
+      throw new IllegalArgumentException("It is not allowed to mix cells with and without index within a single row!")
+
+    val distinctIndexes = indexedCells.map(_.index).toSet.flatten
+    if (indexedCells.size != distinctIndexes.size)
+      throw new IllegalArgumentException("It is not allowed to have cells with duplicate index within a single row!")
+  }
+
+  private[xlsx] def convertSheet(s: Sheet, workbook: SXSSFWorkbook): SXSSFSheet = {
+    s.validate
+    writeToExistingSheet(s, workbook.createSheet(s.nameIn(workbook)))
+  }
+
+  private[xlsx] def writeToExistingSheet(s: Sheet, sheet: SXSSFSheet): SXSSFSheet = {
+    val columns = updateColumnsWithIndexes(s)
+    val columnsMap = columns.map(c => c.index.get -> c).toMap
+
+    s.rows.foreach(row => convertRow(columnsMap, row, s, sheet))
+    columns.foreach(c => convertColumn(c, sheet))
+    s.mergedRegions.foreach(mergedRegion => sheet.addMergedRegion(convertCellRange(mergedRegion)))
+
+    s.printSetup.foreach(ps => convertPrintSetup(ps, sheet))
+    s.header.foreach(h => convertHeader(h, sheet))
+    s.footer.foreach(f => convertFooter(f, sheet))
+
+    s.properties.foreach(sp => convertSheetProperties(sp, sheet))
+    s.margins.foreach(m => convertMargins(m, sheet))
+    s.paneAction.foreach(pa => convertPaneAction(pa, sheet))
+    s.repeatingRows.foreach(rr => sheet.setRepeatingRows(convertRowRange(rr)))
+    s.repeatingColumns.foreach(rc => sheet.setRepeatingColumns(convertColumnRange(rc)))
+    s.password.foreach(ps => sheet.protectSheet(ps))
+
+    if(!s.tables.isEmpty) {
+      throw  new IllegalStateException("createTable is not supported by SXSSF right now")
+    }
+
+    sheet
+  }
+  private def validateRows(s: Sheet) {
+    val indexedRows = s.rows.filter(_.index.isDefined)
+    val contextRows = s.rows.filter(_.index.isEmpty)
+
+    if (indexedRows.nonEmpty && contextRows.nonEmpty) {
+      throw new IllegalArgumentException("It is not allowed to mix rows with and without index within a single sheet!")
+    }
+
+    val distinctIndexes = indexedRows.flatMap(_.index).toSet
+    if (indexedRows.size != distinctIndexes.size)
+      throw new IllegalArgumentException("It is not allowed to have rows with duplicate index within a single sheet!")
+  }
+
+  private def updateColumnsWithIndexes(s: Sheet): List[Column] = {
+    val currentColumnIndexes = s.columns.flatMap(_.index).toSet
+    if (currentColumnIndexes.isEmpty) {
+      s.columns.zipWithIndex.map {
+        case (column, index) => column.withIndex(index)
+      }
+    } else if (currentColumnIndexes.size == s.columns.size) {
+      s.columns
+    } else {
+      throw new IllegalArgumentException(
+        "When explicitly specifying column index you are required to provide it " +
+          "uniquely for all columns in this sheet definition!")
+    }
+  }
+
+  private[xlsx] def convertSheetProperties(sp: SheetProperties, sheet: SXSSFSheet) {
+    sp.autoFilter.foreach(autoFilterRange => sheet.setAutoFilter(convertCellRange(autoFilterRange)))
+    sp.activeCell.foreach(stringReference => sheet.setActiveCell(new CellAddress(stringReference)))
+    sp.autoBreaks.foreach(sheet.setAutobreaks)
+    sp.defaultColumnWidth.foreach(sheet.setDefaultColumnWidth)
+    sp.defaultRowHeight.foreach(height => sheet.setDefaultRowHeightInPoints(height.toPoints))
+    sp.displayFormulas.foreach(sheet.setDisplayFormulas)
+    sp.displayGridLines.foreach(sheet.setDisplayGridlines)
+    sp.displayGuts.foreach(sheet.setDisplayGuts)
+    sp.displayRowColHeadings.foreach(sheet.setDisplayRowColHeadings)
+    sp.displayZeros.foreach(sheet.setDisplayZeros)
+    sp.fitToPage.foreach(sheet.setFitToPage)
+    sp.forceFormulaRecalculation.foreach(sheet.setForceFormulaRecalculation)
+    sp.horizontallyCenter.foreach(sheet.setHorizontallyCenter)
+    sp.printArea.foreach {
+      case CellRange((startRow, endRow), (startColumn, endColumn)) =>
+        val workbook = sheet.getWorkbook
+        val sheetIndex = workbook.getNumberOfSheets - 1
+        workbook.setPrintArea(sheetIndex, startColumn, endColumn, startRow, endRow)
+    }
+    sp.printGridLines.foreach(sheet.setPrintGridlines)
+    sp.rightToLeft.foreach(sheet.setRightToLeft)
+    sp.rowSumsBelow.foreach(sheet.setRowSumsBelow)
+    sp.rowSumsRight.foreach(sheet.setRowSumsRight)
+    sp.selected.foreach(sheet.setSelected)
+    sp.tabColor.foreach(c => sheet.setTabColor(convertColor(c)))
+    sp.virtuallyCenter.foreach(sheet.setVerticallyCenter)
+    sp.zoom.foreach(sheet.setZoom)
+  }
+
+  private def convertPrintSetup(printSetup: PrintSetup, sheet: SXSSFSheet) {
+    if (printSetup != PrintSetup.Default) {
+      val ps = sheet.getPrintSetup.asInstanceOf[XSSFPrintSetup]
+      printSetup.copies.foreach(ps.setCopies)
+      printSetup.draft.foreach(ps.setDraft)
+      printSetup.fitHeight.foreach(ps.setFitHeight)
+      printSetup.fitWidth.foreach(ps.setFitWidth)
+      printSetup.footerMargin.foreach(ps.setFooterMargin)
+      printSetup.headerMargin.foreach(ps.setHeaderMargin)
+      printSetup.hResolution.foreach(ps.setHResolution)
+      printSetup.landscape.foreach(ps.setLandscape)
+      printSetup.leftToRight.foreach(ps.setLeftToRight)
+      printSetup.noColor.foreach(ps.setNoColor)
+      printSetup.noOrientation.foreach(ps.setNoOrientation)
+      printSetup.pageOrder.foreach(po => ps.setPageOrder(convertPageOrder(po)))
+      printSetup.pageStart.foreach(ps.setPageStart)
+      printSetup.paperSize.foreach(px => ps.setPaperSize(convertPaperSize(px)))
+      printSetup.scale.foreach(ps.setScale)
+      printSetup.usePage.foreach(ps.setUsePage)
+      printSetup.validSettings.foreach(ps.setValidSettings)
+      printSetup.vResolution.foreach(ps.setVResolution)
+    }
+  }
+
+  private def convertRowRange(rr: RowRange) =
+    CellRangeAddress.valueOf("%d:%d".format(rr.firstRowIndex, rr.lastRowIndex))
+
+  private[xlsx] def validateTables(modelSheet: Sheet): Unit = {
+    val ids = modelSheet.tables.flatMap(_.id)
+    if (ids.size != ids.toSet.size)
+      throw new IllegalArgumentException("Specified table ids need to be unique.")
+  }
+
+  private[xlsx] def validateTableColumns(modelTable: Table): Unit = {
+
+    def insufficientColumnsDefined = {
+      val (sCol, eCol) = modelTable.cellRange.columnRange
+      val neededColumns = (eCol - sCol) + 1
+      val definedColumns = modelTable.columns.size
+      neededColumns != definedColumns
+    }
+
+    if (modelTable.columns.nonEmpty && insufficientColumnsDefined) {
+      throw new IllegalArgumentException(
+        "When explicitly specifying table columns you are required to provide as many " +
+          "columns as in the cell range."
+      )
+    }
+  }
+
+  private[xlsx] def convertTableColumns(modelTable: Table, ctTable: CTTable): CTTableColumns = {
+
+    def generateColumns = {
+      val (sCol, eCol) = modelTable.cellRange.columnRange
+      val neededColumns = (eCol - sCol) + 1
+      (0 until neededColumns) map { index ⇒
+        val columnId = index + 1
+        TableColumn(
+          name = s"TableColumn$columnId",
+          id = columnId.toLong
+        )
+      }
+    }
+
+    val modelColumns = if (modelTable.columns.nonEmpty) modelTable.columns else generateColumns
+    val columns = ctTable.addNewTableColumns()
+    columns.setCount(modelColumns.size)
+    modelColumns.foreach { mc ⇒
+      val column = columns.addNewTableColumn()
+      column.setName(mc.name)
+      column.setId(mc.id)
+    }
+    columns
+  }
+
+  private[xlsx] def convertTableStyle(modelTableStyle: TableStyle, ctTable: CTTable): CTTableStyleInfo = {
+    val style = ctTable.addNewTableStyleInfo()
+    style.setName(modelTableStyle.name.value)
+    modelTableStyle.showColumnStripes.foreach(style.setShowColumnStripes)
+    modelTableStyle.showRowStripes.foreach(style.setShowRowStripes)
+    style
+  }
+
+  private[xlsx] def setTableReference(modelTable: Table, ctTable: CTTable): Unit = {
+    val cellRangeAddress = convertCellRange(modelTable.cellRange)
+    ctTable.setRef(cellRangeAddress.formatAsString())
+  }
+
+  private[xlsx] def convertWorkbook(wb: Workbook): SXSSFWorkbook = {
+    writeToExistingWorkbook(wb, new SXSSFWorkbook())
+  }
+
+  private[xlsx] def writeToExistingWorkbook(wb: Workbook, workbook: SXSSFWorkbook): SXSSFWorkbook = {
+    wb.sheets.foreach { s =>
+      s.validate
+      val sheetName = s.nameIn(workbook)
+      writeToExistingSheet(s, Option(workbook.getSheet(sheetName)).getOrElse(workbook.createSheet(sheetName)))
+    }
+
+    //Parameters
+    wb.activeSheet.foreach(workbook.setActiveSheet)
+    wb.firstVisibleTab.foreach(workbook.setFirstVisibleTab)
+    wb.forceFormulaRecalculation.foreach(workbook.setForceFormulaRecalculation)
+    wb.hidden.foreach(workbook.setHidden)
+    wb.missingCellPolicy.foreach(mcp => workbook.setMissingCellPolicy(convertMissingCellPolicy(mcp)))
+    wb.selectedTab.foreach(workbook.setSelectedTab)
+    evictFromCache(workbook)
+    workbook
+  }
+  private def evictFromCache(wb: SXSSFWorkbook) {
+    cellStyleCache.remove(wb)
+    dataFormatCache.remove(wb)
+    fontCache.remove(wb)
+  }
+
+  //================= Cache processing ====================
+  private def getCachedOrUpdate[K, V](cache: Cache[K, V], value: K, workbook: SXSSFWorkbook)(newValue: => V): V = {
+    val workbookCache = cache.getOrElseUpdate(workbook, collection.mutable.Map[K, V]())
+    workbookCache.getOrElseUpdate(value, newValue)
+  }
+
+  implicit class XlsxBorderStyle(bs: CellBorderStyle) {
+    def convertAsXlsx(): BorderStyle = convertBorderStyle(bs)
+  }
+
+  implicit class XlsxColor(c: Color) {
+    def convertAsXlsx(): XSSFColor = convertColor(c)
+  }
+
+  implicit class XlsxCellFill(cf: CellFill) {
+    def convertAsXlsx(): FillPatternType = convertCellFill(cf)
+  }
+
+  implicit class XlsxCellStyle(cs: CellStyle) {
+    def convertAsXlsx(cell: SXSSFCell): XSSFCellStyle = convertAsXlsx(cell.getRow.asInstanceOf[SXSSFRow])
+
+    def convertAsXlsx(row: SXSSFRow): XSSFCellStyle = convertAsXlsx(row.getSheet)
+
+    def convertAsXlsx(sheet: SXSSFSheet): XSSFCellStyle = convertAsXlsx(sheet.getWorkbook)
+
+    def convertAsXlsx(workbook: SXSSFWorkbook): XSSFCellStyle = convertCellStyle(cs, workbook)
+  }
+
+  implicit class XlsxFont(f: Font) {
+    def convertAsXlsx(cell: SXSSFCell): XSSFFont = convertAsXlsx(cell.getRow.asInstanceOf[SXSSFRow])
+
+    def convertAsXlsx(row: SXSSFRow): XSSFFont = convertAsXlsx(row.getSheet)
+
+    def convertAsXlsx(sheet: SXSSFSheet): XSSFFont = convertAsXlsx(sheet.getWorkbook)
+
+    def convertAsXlsx(workbook: SXSSFWorkbook): XSSFFont = convertFont(f, workbook)
+  }
+
+  implicit class XlsxHorizontalAlignment(ha: CellHorizontalAlignment) {
+    def convertAsXlsx(): HorizontalAlignment = convertHorizontalAlignment(ha)
+  }
+
+  sealed trait XlsxExport {
+    def saveAsXlsx(fileName: String): Unit
+
+    def writeToOutputStream[T <: OutputStream](stream: T): T
+  }
+
+  implicit class XlsxSheet(s: Sheet) extends XlsxExport {
+    def validate: Unit = {
+      validateRows(s)
+      validateTables(s)
+    }
+
+    def nameIn(workbook: SXSSFWorkbook): String = s.name.getOrElse("Sheet" + (workbook.getNumberOfSheets + 1))
+
+    def writeToExisting(existingSheet: SXSSFSheet): Unit = writeToExistingSheet(s, existingSheet)
+
+    def convertAsXlsx(workbook: SXSSFWorkbook): SXSSFSheet = convertSheet(s, workbook)
+
+    def convertAsXlsx(): SXSSFWorkbook = Workbook(s).convertAsXlsx()
+
+    override def saveAsXlsx(fileName: String) {
+      Workbook(s).saveAsXlsx(fileName)
+    }
+
+    override def writeToOutputStream[T <: OutputStream](stream: T): T = Workbook(s).writeToOutputStream(stream)
+  }
+
+  implicit class XlsxVerticalAlignment(va: CellVerticalAlignment) {
+    def convertAsXlsx(): VerticalAlignment = convertVerticalAlignment(va)
+  }
+
+  implicit class XlsxWorkbook(workbook: Workbook) extends XlsxExport {
+    def writeToExisting(existingWorkBook: SXSSFWorkbook): Unit = writeToExistingWorkbook(workbook, existingWorkBook)
+
+    override def saveAsXlsx(fileName: String): Unit = writeToOutputStream(new FileOutputStream(fileName))
+
+    override def writeToOutputStream[T <: OutputStream](stream: T): T =
+      try {
+        convertAsXlsx().write(stream)
+        stream
+      } finally {
+        stream.flush()
+        stream.close()
+      }
+
+    def convertAsXlsx(): SXSSFWorkbook = convertWorkbook(workbook)
+  }
+
+}

--- a/src/main/scala/com/norbitltd/spoiwo/natures/xlsx/BaseXlsx.scala
+++ b/src/main/scala/com/norbitltd/spoiwo/natures/xlsx/BaseXlsx.scala
@@ -200,8 +200,7 @@ trait BaseXlsx {
     }
   }
 
-  protected[natures] def additionalPrintSetup(printSetup: PrintSetup, sheetPs: usermodel.PrintSetup): Unit = {
-  }
+  protected[natures] def additionalPrintSetup(printSetup: PrintSetup, sheetPs: usermodel.PrintSetup): Unit
 
   protected[natures] def convertRowRange(rr: RowRange) =
     CellRangeAddress.valueOf("%d:%d".format(rr.firstRowIndex, rr.lastRowIndex))

--- a/src/main/scala/com/norbitltd/spoiwo/natures/xlsx/BaseXlsx.scala
+++ b/src/main/scala/com/norbitltd/spoiwo/natures/xlsx/BaseXlsx.scala
@@ -1,0 +1,263 @@
+package com.norbitltd.spoiwo.natures.xlsx
+import java.util.{Calendar, Date}
+
+import com.norbitltd.spoiwo.model._
+import com.norbitltd.spoiwo.model.enums.{CellStyleInheritance, Pane}
+import com.norbitltd.spoiwo.natures.xlsx.Model2XlsxEnumConversions._
+import org.apache.poi.common.usermodel.HyperlinkType
+import org.apache.poi.ss.usermodel
+import org.apache.poi.ss.util.{CellAddress, CellRangeAddress}
+import org.apache.poi.xssf.usermodel._
+import org.joda.time.{LocalDate, LocalDateTime}
+
+trait BaseXlsx {
+
+  private val FirstSupportedDate = new LocalDate(1904, 1, 1)
+  private val LastSupportedDate = new LocalDate(9999, 12, 31)
+
+  protected[natures] def mergeStyle(cell: Cell,
+                         rowStyle: Option[CellStyle],
+                         columnStyle: Option[CellStyle],
+                         sheetStyle: Option[CellStyle]): Cell = {
+    cell.styleInheritance match {
+      case CellStyleInheritance.CellOnly =>
+        cell
+      case CellStyleInheritance.CellThenRow =>
+        cell.withDefaultStyle(rowStyle)
+      case CellStyleInheritance.CellThenColumn =>
+        cell.withDefaultStyle(columnStyle)
+      case CellStyleInheritance.CellThenSheet =>
+        cell.withDefaultStyle(sheetStyle)
+      case CellStyleInheritance.CellThenColumnThenRow =>
+        cell.withDefaultStyle(columnStyle).withDefaultStyle(rowStyle)
+      case CellStyleInheritance.CellThenRowThenColumn =>
+        cell.withDefaultStyle(rowStyle).withDefaultStyle(columnStyle)
+      case CellStyleInheritance.CellThenRowThenSheet =>
+        cell.withDefaultStyle(rowStyle).withDefaultStyle(sheetStyle)
+      case CellStyleInheritance.CellThenColumnThenSheet =>
+        cell.withDefaultStyle(columnStyle).withDefaultStyle(sheetStyle)
+      case CellStyleInheritance.CellThenColumnThenRowThenSheet =>
+        cell.withDefaultStyle(columnStyle).withDefaultStyle(rowStyle).withDefaultStyle(sheetStyle)
+      case CellStyleInheritance.CellThenRowThenColumnThenSheet =>
+        cell.withDefaultStyle(rowStyle).withDefaultStyle(columnStyle).withDefaultStyle(sheetStyle)
+      case unexpected =>
+        throw new IllegalArgumentException(
+          s"Unable to convert CellStyleInheritance=$unexpected to XLSX - unsupported enum!")
+    }
+  }
+
+  protected[natures] def convertColumn(c: Column, sheet: usermodel.Sheet) {
+    val i = c.index.getOrElse(
+      throw new IllegalArgumentException(
+        "Undefined column index! " +
+          "Something went terribly wrong as it should have been derived if not specified explicitly!"))
+
+    c.autoSized.foreach(as => if (as) sheet.autoSizeColumn(i))
+    c.break.foreach(b => if (b) sheet.setColumnBreak(i))
+    c.groupCollapsed.foreach(gc => sheet.setColumnGroupCollapsed(i, gc))
+    c.hidden.foreach(h => sheet.setColumnHidden(i, h))
+    c.width.foreach(w => sheet.setColumnWidth(i, w.toUnits))
+  }
+
+  protected[natures] def convertCellBorders(borders: CellBorders, style: XSSFCellStyle) {
+    borders.leftStyle.foreach(s => style.setBorderLeft(convertBorderStyle(s)))
+    borders.leftColor.foreach(c => style.setLeftBorderColor(convertColor(c)))
+    borders.bottomStyle.foreach(s => style.setBorderBottom(convertBorderStyle(s)))
+    borders.bottomColor.foreach(c => style.setBottomBorderColor(convertColor(c)))
+    borders.rightStyle.foreach(s => style.setBorderRight(convertBorderStyle(s)))
+    borders.rightColor.foreach(c => style.setRightBorderColor(convertColor(c)))
+    borders.topStyle.foreach(s => style.setBorderTop(convertBorderStyle(s)))
+    borders.topColor.foreach(c => style.setTopBorderColor(convertColor(c)))
+  }
+
+  protected[natures] def convertColor(color: Color): XSSFColor = new XSSFColor(
+    Array[Byte](color.r.toByte, color.g.toByte, color.b.toByte),
+    new DefaultIndexedColorMap()
+  )
+
+  protected[natures] def setHyperLinkUrlCell(cell: usermodel.Cell, value: HyperLinkUrl, row: usermodel.Row) {
+    val link = row.getSheet.getWorkbook.getCreationHelper.createHyperlink(HyperlinkType.URL)
+    link.setAddress(value.address)
+    cell.setCellValue(value.text)
+    cell.setHyperlink(link)
+  }
+
+
+  protected[natures] def convertCellRange(cr: CellRange): CellRangeAddress =
+    new org.apache.poi.ss.util.CellRangeAddress(cr.rowRange._1, cr.rowRange._2, cr.columnRange._1, cr.columnRange._2)
+
+  protected[natures] def convertFont(f: Font,
+                          font: XSSFFont) = {
+    f.bold.foreach(font.setBold)
+    f.charSet.foreach(charSet => font.setCharSet(convertCharset(charSet).getNativeId))
+    f.color.foreach(c => font.setColor(convertColor(c)))
+    f.family.foreach(family => font.setFamily(convertFontFamily(family)))
+    f.height.foreach(height => font.setFontHeightInPoints(height.toPoints))
+    f.italic.foreach(font.setItalic)
+    f.scheme.foreach(scheme => font.setScheme(convertFontScheme(scheme)))
+    f.fontName.foreach(font.setFontName)
+    f.strikeout.foreach(font.setStrikeout)
+    f.typeOffset.foreach(offset => font.setTypeOffset(convertTypeOffset(offset)))
+    f.underline.foreach(underline => font.setUnderline(convertUnderline(underline)))
+    font
+  }
+
+  protected[natures] def validateCells(r: Row) {
+    val indexedCells = r.cells.filter(_.index.isDefined)
+    val contextCells = r.cells.filter(_.index.isEmpty)
+
+    if (indexedCells.nonEmpty && contextCells.nonEmpty)
+      throw new IllegalArgumentException("It is not allowed to mix cells with and without index within a single row!")
+
+    val distinctIndexes = indexedCells.map(_.index).toSet.flatten
+    if (indexedCells.size != distinctIndexes.size)
+      throw new IllegalArgumentException("It is not allowed to have cells with duplicate index within a single row!")
+  }
+
+
+  protected[natures] def validateRows(s: Sheet) {
+    val indexedRows = s.rows.filter(_.index.isDefined)
+    val contextRows = s.rows.filter(_.index.isEmpty)
+
+    if (indexedRows.nonEmpty && contextRows.nonEmpty) {
+      throw new IllegalArgumentException("It is not allowed to mix rows with and without index within a single sheet!")
+    }
+
+    val distinctIndexes = indexedRows.flatMap(_.index).toSet
+    if (indexedRows.size != distinctIndexes.size)
+      throw new IllegalArgumentException("It is not allowed to have rows with duplicate index within a single sheet!")
+  }
+
+  protected[natures] def updateColumnsWithIndexes(s: Sheet): List[Column] = {
+    val currentColumnIndexes = s.columns.flatMap(_.index).toSet
+    if (currentColumnIndexes.isEmpty) {
+      s.columns.zipWithIndex.map {
+        case (column, index) => column.withIndex(index)
+      }
+    } else if (currentColumnIndexes.size == s.columns.size) {
+      s.columns
+    } else {
+      throw new IllegalArgumentException(
+        "When explicitly specifying column index you are required to provide it " +
+          "uniquely for all columns in this sheet definition!")
+    }
+  }
+
+
+  protected[natures] def convertSheetProperties(sp: SheetProperties, sheet: usermodel.Sheet) {
+    sp.autoFilter.foreach(autoFilterRange => sheet.setAutoFilter(convertCellRange(autoFilterRange)))
+    sp.activeCell.foreach(stringReference => sheet.setActiveCell(new CellAddress(stringReference)))
+    sp.autoBreaks.foreach(sheet.setAutobreaks)
+    sp.defaultColumnWidth.foreach(sheet.setDefaultColumnWidth)
+    sp.defaultRowHeight.foreach(height => sheet.setDefaultRowHeightInPoints(height.toPoints))
+    sp.displayFormulas.foreach(sheet.setDisplayFormulas)
+    sp.displayGridLines.foreach(sheet.setDisplayGridlines)
+    sp.displayGuts.foreach(sheet.setDisplayGuts)
+    sp.displayRowColHeadings.foreach(sheet.setDisplayRowColHeadings)
+    sp.displayZeros.foreach(sheet.setDisplayZeros)
+    sp.fitToPage.foreach(sheet.setFitToPage)
+    sp.forceFormulaRecalculation.foreach(sheet.setForceFormulaRecalculation)
+    sp.horizontallyCenter.foreach(sheet.setHorizontallyCenter)
+    sp.printArea.foreach {
+      case CellRange((startRow, endRow), (startColumn, endColumn)) =>
+        val workbook = sheet.getWorkbook
+        val sheetIndex = workbook.getNumberOfSheets - 1
+        workbook.setPrintArea(sheetIndex, startColumn, endColumn, startRow, endRow)
+    }
+    sp.printGridLines.foreach(sheet.setPrintGridlines)
+    sp.rightToLeft.foreach(sheet.setRightToLeft)
+    sp.rowSumsBelow.foreach(sheet.setRowSumsBelow)
+    sp.rowSumsRight.foreach(sheet.setRowSumsRight)
+    sp.selected.foreach(sheet.setSelected)
+    sp.tabColor.foreach(c => setTabColor(sheet, convertColor(c)))
+    sp.virtuallyCenter.foreach(sheet.setVerticallyCenter)
+    sp.zoom.foreach(sheet.setZoom)
+  }
+
+  protected[natures] def setTabColor( sheet: usermodel.Sheet, XSSFColor: XSSFColor ): Unit
+
+  protected[natures] def convertPrintSetup(printSetup: PrintSetup, sheet: usermodel.Sheet) {
+    if (printSetup != PrintSetup.Default) {
+      val ps = sheet.getPrintSetup
+      printSetup.copies.foreach(ps.setCopies)
+      printSetup.draft.foreach(ps.setDraft)
+      printSetup.fitHeight.foreach(ps.setFitHeight)
+      printSetup.fitWidth.foreach(ps.setFitWidth)
+      printSetup.footerMargin.foreach(ps.setFooterMargin)
+      printSetup.headerMargin.foreach(ps.setHeaderMargin)
+      printSetup.hResolution.foreach(ps.setHResolution)
+      printSetup.landscape.foreach(ps.setLandscape)
+      printSetup.leftToRight.foreach(ps.setLeftToRight)
+      printSetup.noColor.foreach(ps.setNoColor)
+      printSetup.noOrientation.foreach(ps.setNoOrientation)
+      printSetup.pageStart.foreach(ps.setPageStart)
+      printSetup.scale.foreach(ps.setScale)
+      printSetup.usePage.foreach(ps.setUsePage)
+      printSetup.validSettings.foreach(ps.setValidSettings)
+      printSetup.vResolution.foreach(ps.setVResolution)
+
+      additionalPrintSetup(printSetup, ps)
+    }
+  }
+
+  protected[natures] def additionalPrintSetup(printSetup: PrintSetup, sheetPs: usermodel.PrintSetup): Unit = {
+  }
+
+  protected[natures] def convertRowRange(rr: RowRange) =
+    CellRangeAddress.valueOf("%d:%d".format(rr.firstRowIndex, rr.lastRowIndex))
+
+  protected[natures] def convertColumnRange(cr: ColumnRange) =
+    CellRangeAddress.valueOf("%s:%s".format(cr.firstColumnName, cr.lastColumnName))
+
+  protected[natures] def setDateCell(c: Cell, cell: usermodel.Cell, value: Date) {
+    val dateStyle = c.format.getOrElse("yyyy-MM-dd")
+    val dateTime = LocalDateTime.fromDateFields(value)
+    val date = dateTime.toLocalDate
+    if (date.isBefore(FirstSupportedDate) || date.isAfter(LastSupportedDate)) {
+      cell.setCellValue(dateTime.toString(dateStyle))
+    } else {
+      cell.setCellValue(value)
+    }
+  }
+
+  protected[natures] def setCalendarCell(c: Cell, cell: usermodel.Cell, value: Calendar) {
+    val dateStyle = c.format.getOrElse("yyyy-MM-dd")
+    val dateTime = LocalDateTime.fromCalendarFields(value)
+    val date = dateTime.toLocalDate
+    if (date.isBefore(FirstSupportedDate) || date.isAfter(LastSupportedDate)) {
+      cell.setCellValue(dateTime.toString(dateStyle))
+    } else {
+      cell.setCellValue(value)
+    }
+  }
+
+  protected[natures] def convertPane(pane: Pane): Int = pane match {
+    case Pane.LowerLeftPane  => org.apache.poi.ss.usermodel.Sheet.PANE_LOWER_LEFT
+    case Pane.LowerRightPane => org.apache.poi.ss.usermodel.Sheet.PANE_LOWER_RIGHT
+    case Pane.UpperLeftPane  => org.apache.poi.ss.usermodel.Sheet.PANE_UPPER_LEFT
+    case Pane.UpperRightPane => org.apache.poi.ss.usermodel.Sheet.PANE_UPPER_RIGHT
+    case unexpected =>
+      throw new IllegalArgumentException(s"Unable to convert Pane=$unexpected to XLSX - unsupported enum!")
+  }
+
+  protected[natures] def convertPaneAction(paneAction: PaneAction, sheet: usermodel.Sheet) {
+    paneAction match {
+      case NoSplitOrFreeze() =>
+        sheet.createFreezePane(0, 0)
+      case FreezePane(columnSplit, rowSplit, leftMostColumn, topRow) =>
+        sheet.createFreezePane(columnSplit, rowSplit, leftMostColumn, topRow)
+      case SplitPane(xSplitPosition, ySplitPosition, leftMostColumn, topRow, activePane) =>
+        sheet.createSplitPane(xSplitPosition, ySplitPosition, leftMostColumn, topRow, convertPane(activePane))
+    }
+  }
+
+  protected[natures] def convertMargins(margins: Margins, sheet: usermodel.Sheet) {
+    margins.top.foreach(topMargin => sheet.setMargin(usermodel.Sheet.TopMargin, topMargin))
+    margins.bottom.foreach(bottomMargin => sheet.setMargin(usermodel.Sheet.BottomMargin, bottomMargin))
+    margins.right.foreach(rightMargin => sheet.setMargin(usermodel.Sheet.RightMargin, rightMargin))
+    margins.left.foreach(leftMargin => sheet.setMargin(usermodel.Sheet.LeftMargin, leftMargin))
+    margins.header.foreach(headerMargin => sheet.setMargin(usermodel.Sheet.HeaderMargin, headerMargin))
+    margins.footer.foreach(footerMargin => sheet.setMargin(usermodel.Sheet.FooterMargin, footerMargin))
+  }
+
+}

--- a/src/main/scala/com/norbitltd/spoiwo/natures/xlsx/Model2XlsxConversions.scala
+++ b/src/main/scala/com/norbitltd/spoiwo/natures/xlsx/Model2XlsxConversions.scala
@@ -1,75 +1,24 @@
 package com.norbitltd.spoiwo.natures.xlsx
 
 import java.io.{FileOutputStream, OutputStream}
-import java.util.{Calendar, Date}
 
 import com.norbitltd.spoiwo.model.enums._
-import com.norbitltd.spoiwo.model.{
-  BooleanCell,
-  CalendarCell,
-  DateCell,
-  FormulaCell,
-  NoSplitOrFreeze,
-  NumericCell,
-  SplitPane,
-  StringCell,
-  _
-}
+import com.norbitltd.spoiwo.model.{BooleanCell, CalendarCell, DateCell, FormulaCell, NumericCell, StringCell, _}
 import com.norbitltd.spoiwo.natures.xlsx.Model2XlsxEnumConversions._
-import org.apache.poi.common.usermodel.HyperlinkType
 import org.apache.poi.ss.usermodel
 import org.apache.poi.ss.usermodel.{BorderStyle, CellType, FillPatternType, HorizontalAlignment, VerticalAlignment}
-import org.apache.poi.ss.util.{CellAddress, CellRangeAddress}
+import org.apache.poi.xssf.streaming.SXSSFSheet
 import org.apache.poi.xssf.usermodel._
-import org.joda.time.{LocalDate, LocalDateTime}
 import org.openxmlformats.schemas.spreadsheetml.x2006.main.{CTTable, CTTableColumns, CTTableStyleInfo}
 
-object Model2XlsxConversions {
+object Model2XlsxConversions extends BaseXlsx {
 
   private type Cache[K, V] = collection.mutable.Map[XSSFWorkbook, collection.mutable.Map[K, V]]
   private lazy val cellStyleCache = Cache[CellStyle, XSSFCellStyle]()
   private lazy val dataFormatCache = collection.mutable.Map[XSSFWorkbook, XSSFDataFormat]()
   private lazy val fontCache = Cache[Font, XSSFFont]()
-  private val FirstSupportedDate = new LocalDate(1904, 1, 1)
-  private val LastSupportedDate = new LocalDate(9999, 12, 31)
 
   private def Cache[K, V]() = collection.mutable.Map[XSSFWorkbook, collection.mutable.Map[K, V]]()
-
-  private def convertColor(color: Color): XSSFColor = new XSSFColor(
-    Array[Byte](color.r.toByte, color.g.toByte, color.b.toByte),
-    new DefaultIndexedColorMap()
-  )
-
-  private def mergeStyle(cell: Cell,
-                         rowStyle: Option[CellStyle],
-                         columnStyle: Option[CellStyle],
-                         sheetStyle: Option[CellStyle]): Cell = {
-    cell.styleInheritance match {
-      case CellStyleInheritance.CellOnly =>
-        cell
-      case CellStyleInheritance.CellThenRow =>
-        cell.withDefaultStyle(rowStyle)
-      case CellStyleInheritance.CellThenColumn =>
-        cell.withDefaultStyle(columnStyle)
-      case CellStyleInheritance.CellThenSheet =>
-        cell.withDefaultStyle(sheetStyle)
-      case CellStyleInheritance.CellThenColumnThenRow =>
-        cell.withDefaultStyle(columnStyle).withDefaultStyle(rowStyle)
-      case CellStyleInheritance.CellThenRowThenColumn =>
-        cell.withDefaultStyle(rowStyle).withDefaultStyle(columnStyle)
-      case CellStyleInheritance.CellThenRowThenSheet =>
-        cell.withDefaultStyle(rowStyle).withDefaultStyle(sheetStyle)
-      case CellStyleInheritance.CellThenColumnThenSheet =>
-        cell.withDefaultStyle(columnStyle).withDefaultStyle(sheetStyle)
-      case CellStyleInheritance.CellThenColumnThenRowThenSheet =>
-        cell.withDefaultStyle(columnStyle).withDefaultStyle(rowStyle).withDefaultStyle(sheetStyle)
-      case CellStyleInheritance.CellThenRowThenColumnThenSheet =>
-        cell.withDefaultStyle(rowStyle).withDefaultStyle(columnStyle).withDefaultStyle(sheetStyle)
-      case unexpected =>
-        throw new IllegalArgumentException(
-          s"Unable to convert CellStyleInheritance=$unexpected to XLSX - unsupported enum!")
-    }
-  }
 
   private[xlsx] def convertCell(modelSheet: Sheet,
                                 modelColumns: Map[Int, Column],
@@ -98,45 +47,6 @@ object Model2XlsxConversions {
     cell
   }
 
-  private def setDateCell(c: Cell, cell: XSSFCell, value: Date) {
-    val dateStyle = c.format.getOrElse("yyyy-MM-dd")
-    val dateTime = LocalDateTime.fromDateFields(value)
-    val date = dateTime.toLocalDate
-    if (date.isBefore(FirstSupportedDate) || date.isAfter(LastSupportedDate)) {
-      cell.setCellValue(dateTime.toString(dateStyle))
-    } else {
-      cell.setCellValue(value)
-    }
-  }
-
-  private def setCalendarCell(c: Cell, cell: XSSFCell, value: Calendar) {
-    val dateStyle = c.format.getOrElse("yyyy-MM-dd")
-    val dateTime = LocalDateTime.fromCalendarFields(value)
-    val date = dateTime.toLocalDate
-    if (date.isBefore(FirstSupportedDate) || date.isAfter(LastSupportedDate)) {
-      cell.setCellValue(dateTime.toString(dateStyle))
-    } else {
-      cell.setCellValue(value)
-    }
-  }
-  private def setHyperLinkUrlCell(cell: XSSFCell, value: HyperLinkUrl, row: XSSFRow) {
-    val link = row.getSheet.getWorkbook.getCreationHelper.createHyperlink(HyperlinkType.URL)
-    link.setAddress(value.address)
-    cell.setCellValue(value.text)
-    cell.setHyperlink(link)
-
-  }
-  private[xlsx] def convertCellBorders(borders: CellBorders, style: XSSFCellStyle) {
-    borders.leftStyle.foreach(s => style.setBorderLeft(convertBorderStyle(s)))
-    borders.leftColor.foreach(c => style.setLeftBorderColor(convertColor(c)))
-    borders.bottomStyle.foreach(s => style.setBorderBottom(convertBorderStyle(s)))
-    borders.bottomColor.foreach(c => style.setBottomBorderColor(convertColor(c)))
-    borders.rightStyle.foreach(s => style.setBorderRight(convertBorderStyle(s)))
-    borders.rightColor.foreach(c => style.setRightBorderColor(convertColor(c)))
-    borders.topStyle.foreach(s => style.setBorderTop(convertBorderStyle(s)))
-    borders.topColor.foreach(c => style.setTopBorderColor(convertColor(c)))
-  }
-
   private def convertCellDataFormat(cdf: CellDataFormat, workbook: XSSFWorkbook, cellStyle: XSSFCellStyle) {
     cdf.formatString.foreach(formatString => {
       val format = dataFormatCache.getOrElseUpdate(workbook, workbook.createDataFormat())
@@ -144,9 +54,6 @@ object Model2XlsxConversions {
       cellStyle.setDataFormat(formatIndex)
     })
   }
-
-  private def convertCellRange(cr: CellRange): CellRangeAddress =
-    new org.apache.poi.ss.util.CellRangeAddress(cr.rowRange._1, cr.rowRange._2, cr.columnRange._1, cr.columnRange._2)
 
   private[xlsx] def convertCellStyle(cs: CellStyle, workbook: XSSFWorkbook): XSSFCellStyle =
     getCachedOrUpdate(cellStyleCache, cs, workbook) {
@@ -169,22 +76,6 @@ object Model2XlsxConversions {
       cellStyle
     }
 
-  private[xlsx] def convertColumn(c: Column, sheet: XSSFSheet) {
-    val i = c.index.getOrElse(
-      throw new IllegalArgumentException(
-        "Undefined column index! " +
-          "Something went terribly wrong as it should have been derived if not specified explicitly!"))
-
-    c.autoSized.foreach(as => if (as) sheet.autoSizeColumn(i))
-    c.break.foreach(b => if (b) sheet.setColumnBreak(i))
-    c.groupCollapsed.foreach(gc => sheet.setColumnGroupCollapsed(i, gc))
-    c.hidden.foreach(h => sheet.setColumnHidden(i, h))
-    c.width.foreach(w => sheet.setColumnWidth(i, w.toUnits))
-  }
-
-  private def convertColumnRange(cr: ColumnRange) =
-    CellRangeAddress.valueOf("%s:%s".format(cr.firstColumnName, cr.lastColumnName))
-
   private def convertFooter(f: Footer, sheet: XSSFSheet) {
     f.left.foreach(sheet.getFooter.setLeft)
     f.center.foreach(sheet.getFooter.setCenter)
@@ -206,18 +97,7 @@ object Model2XlsxConversions {
   private[xlsx] def convertFont(f: Font, workbook: XSSFWorkbook): XSSFFont =
     getCachedOrUpdate(fontCache, f, workbook) {
       val font = workbook.createFont()
-      f.bold.foreach(font.setBold)
-      f.charSet.foreach(charSet => font.setCharSet(convertCharset(charSet).getNativeId))
-      f.color.foreach(c => font.setColor(convertColor(c)))
-      f.family.foreach(family => font.setFamily(convertFontFamily(family)))
-      f.height.foreach(height => font.setFontHeightInPoints(height.toPoints))
-      f.italic.foreach(font.setItalic)
-      f.scheme.foreach(scheme => font.setScheme(convertFontScheme(scheme)))
-      f.fontName.foreach(font.setFontName)
-      f.strikeout.foreach(font.setStrikeout)
-      f.typeOffset.foreach(offset => font.setTypeOffset(convertTypeOffset(offset)))
-      f.underline.foreach(underline => font.setUnderline(convertUnderline(underline)))
-      font
+      convertFont(f, font)
     }
 
   private def convertHeader(h: Header, sheet: XSSFSheet) {
@@ -238,35 +118,6 @@ object Model2XlsxConversions {
     h.evenRight.foreach(sheet.getEvenHeader.setRight)
   }
 
-  private def convertMargins(margins: Margins, sheet: XSSFSheet) {
-    margins.top.foreach(topMargin => sheet.setMargin(usermodel.Sheet.TopMargin, topMargin))
-    margins.bottom.foreach(bottomMargin => sheet.setMargin(usermodel.Sheet.BottomMargin, bottomMargin))
-    margins.right.foreach(rightMargin => sheet.setMargin(usermodel.Sheet.RightMargin, rightMargin))
-    margins.left.foreach(leftMargin => sheet.setMargin(usermodel.Sheet.LeftMargin, leftMargin))
-    margins.header.foreach(headerMargin => sheet.setMargin(usermodel.Sheet.HeaderMargin, headerMargin))
-    margins.footer.foreach(footerMargin => sheet.setMargin(usermodel.Sheet.FooterMargin, footerMargin))
-  }
-
-  private def convertPane(pane: Pane): Int = pane match {
-    case Pane.LowerLeftPane  => org.apache.poi.ss.usermodel.Sheet.PANE_LOWER_LEFT
-    case Pane.LowerRightPane => org.apache.poi.ss.usermodel.Sheet.PANE_LOWER_RIGHT
-    case Pane.UpperLeftPane  => org.apache.poi.ss.usermodel.Sheet.PANE_UPPER_LEFT
-    case Pane.UpperRightPane => org.apache.poi.ss.usermodel.Sheet.PANE_UPPER_RIGHT
-    case unexpected =>
-      throw new IllegalArgumentException(s"Unable to convert Pane=$unexpected to XLSX - unsupported enum!")
-  }
-
-  private def convertPaneAction(paneAction: PaneAction, sheet: XSSFSheet) {
-    paneAction match {
-      case NoSplitOrFreeze() =>
-        sheet.createFreezePane(0, 0)
-      case FreezePane(columnSplit, rowSplit, leftMostColumn, topRow) =>
-        sheet.createFreezePane(columnSplit, rowSplit, leftMostColumn, topRow)
-      case SplitPane(xSplitPosition, ySplitPosition, leftMostColumn, topRow, activePane) =>
-        sheet.createSplitPane(xSplitPosition, ySplitPosition, leftMostColumn, topRow, convertPane(activePane))
-    }
-  }
-
   private[xlsx] def convertRow(modelColumns: Map[Int, Column],
                                modelRow: Row,
                                modelSheet: Sheet,
@@ -279,18 +130,6 @@ object Model2XlsxConversions {
     modelRow.hidden.foreach(row.setZeroHeight)
     modelRow.cells.foreach(cell => convertCell(modelSheet, modelColumns, modelRow, cell, row))
     row
-  }
-
-  private def validateCells(r: Row) {
-    val indexedCells = r.cells.filter(_.index.isDefined)
-    val contextCells = r.cells.filter(_.index.isEmpty)
-
-    if (indexedCells.nonEmpty && contextCells.nonEmpty)
-      throw new IllegalArgumentException("It is not allowed to mix cells with and without index within a single row!")
-
-    val distinctIndexes = indexedCells.map(_.index).toSet.flatten
-    if (indexedCells.size != distinctIndexes.size)
-      throw new IllegalArgumentException("It is not allowed to have cells with duplicate index within a single row!")
   }
 
   private[xlsx] def convertSheet(s: Sheet, workbook: XSSFWorkbook): XSSFSheet = {
@@ -320,90 +159,18 @@ object Model2XlsxConversions {
     tables.foreach(tbl ⇒ convertTable(tbl, sheet))
     sheet
   }
-  private def validateRows(s: Sheet) {
-    val indexedRows = s.rows.filter(_.index.isDefined)
-    val contextRows = s.rows.filter(_.index.isEmpty)
 
-    if (indexedRows.nonEmpty && contextRows.nonEmpty) {
-      throw new IllegalArgumentException("It is not allowed to mix rows with and without index within a single sheet!")
-    }
-
-    val distinctIndexes = indexedRows.flatMap(_.index).toSet
-    if (indexedRows.size != distinctIndexes.size)
-      throw new IllegalArgumentException("It is not allowed to have rows with duplicate index within a single sheet!")
+  override def setTabColor(sheet: usermodel.Sheet, color: XSSFColor) {
+    sheet.asInstanceOf[SXSSFSheet].setTabColor(color)
   }
 
-  private def updateColumnsWithIndexes(s: Sheet): List[Column] = {
-    val currentColumnIndexes = s.columns.flatMap(_.index).toSet
-    if (currentColumnIndexes.isEmpty) {
-      s.columns.zipWithIndex.map {
-        case (column, index) => column.withIndex(index)
-      }
-    } else if (currentColumnIndexes.size == s.columns.size) {
-      s.columns
-    } else {
-      throw new IllegalArgumentException(
-        "When explicitly specifying column index you are required to provide it " +
-          "uniquely for all columns in this sheet definition!")
-    }
-  }
-
-  private[xlsx] def convertSheetProperties(sp: SheetProperties, sheet: XSSFSheet) {
-    sp.autoFilter.foreach(autoFilterRange => sheet.setAutoFilter(convertCellRange(autoFilterRange)))
-    sp.activeCell.foreach(stringReference => sheet.setActiveCell(new CellAddress(stringReference)))
-    sp.autoBreaks.foreach(sheet.setAutobreaks)
-    sp.defaultColumnWidth.foreach(sheet.setDefaultColumnWidth)
-    sp.defaultRowHeight.foreach(height => sheet.setDefaultRowHeightInPoints(height.toPoints))
-    sp.displayFormulas.foreach(sheet.setDisplayFormulas)
-    sp.displayGridLines.foreach(sheet.setDisplayGridlines)
-    sp.displayGuts.foreach(sheet.setDisplayGuts)
-    sp.displayRowColHeadings.foreach(sheet.setDisplayRowColHeadings)
-    sp.displayZeros.foreach(sheet.setDisplayZeros)
-    sp.fitToPage.foreach(sheet.setFitToPage)
-    sp.forceFormulaRecalculation.foreach(sheet.setForceFormulaRecalculation)
-    sp.horizontallyCenter.foreach(sheet.setHorizontallyCenter)
-    sp.printArea.foreach {
-      case CellRange((startRow, endRow), (startColumn, endColumn)) =>
-        val workbook = sheet.getWorkbook
-        val sheetIndex = workbook.getNumberOfSheets - 1
-        workbook.setPrintArea(sheetIndex, startColumn, endColumn, startRow, endRow)
-    }
-    sp.printGridLines.foreach(sheet.setPrintGridlines)
-    sp.rightToLeft.foreach(sheet.setRightToLeft)
-    sp.rowSumsBelow.foreach(sheet.setRowSumsBelow)
-    sp.rowSumsRight.foreach(sheet.setRowSumsRight)
-    sp.selected.foreach(sheet.setSelected)
-    sp.tabColor.foreach(c => sheet.setTabColor(convertColor(c)))
-    sp.virtuallyCenter.foreach(sheet.setVerticallyCenter)
-    sp.zoom.foreach(sheet.setZoom)
-  }
-
-  private def convertPrintSetup(printSetup: PrintSetup, sheet: XSSFSheet) {
+  override def additionalPrintSetup(printSetup: PrintSetup, sheetPs: usermodel.PrintSetup) {
     if (printSetup != PrintSetup.Default) {
-      val ps = sheet.getPrintSetup
-      printSetup.copies.foreach(ps.setCopies)
-      printSetup.draft.foreach(ps.setDraft)
-      printSetup.fitHeight.foreach(ps.setFitHeight)
-      printSetup.fitWidth.foreach(ps.setFitWidth)
-      printSetup.footerMargin.foreach(ps.setFooterMargin)
-      printSetup.headerMargin.foreach(ps.setHeaderMargin)
-      printSetup.hResolution.foreach(ps.setHResolution)
-      printSetup.landscape.foreach(ps.setLandscape)
-      printSetup.leftToRight.foreach(ps.setLeftToRight)
-      printSetup.noColor.foreach(ps.setNoColor)
-      printSetup.noOrientation.foreach(ps.setNoOrientation)
+      val ps = sheetPs.asInstanceOf[XSSFPrintSetup]
       printSetup.pageOrder.foreach(po => ps.setPageOrder(convertPageOrder(po)))
-      printSetup.pageStart.foreach(ps.setPageStart)
       printSetup.paperSize.foreach(px => ps.setPaperSize(convertPaperSize(px)))
-      printSetup.scale.foreach(ps.setScale)
-      printSetup.usePage.foreach(ps.setUsePage)
-      printSetup.validSettings.foreach(ps.setValidSettings)
-      printSetup.vResolution.foreach(ps.setVResolution)
     }
   }
-
-  private def convertRowRange(rr: RowRange) =
-    CellRangeAddress.valueOf("%d:%d".format(rr.firstRowIndex, rr.lastRowIndex))
 
   private[xlsx] def validateTables(modelSheet: Sheet): Unit = {
     val ids = modelSheet.tables.flatMap(_.id)

--- a/src/main/scala/com/norbitltd/spoiwo/natures/xlsx/Model2XlsxConversions.scala
+++ b/src/main/scala/com/norbitltd/spoiwo/natures/xlsx/Model2XlsxConversions.scala
@@ -7,7 +7,6 @@ import com.norbitltd.spoiwo.model.{BooleanCell, CalendarCell, DateCell, FormulaC
 import com.norbitltd.spoiwo.natures.xlsx.Model2XlsxEnumConversions._
 import org.apache.poi.ss.usermodel
 import org.apache.poi.ss.usermodel.{BorderStyle, CellType, FillPatternType, HorizontalAlignment, VerticalAlignment}
-import org.apache.poi.xssf.streaming.SXSSFSheet
 import org.apache.poi.xssf.usermodel._
 import org.openxmlformats.schemas.spreadsheetml.x2006.main.{CTTable, CTTableColumns, CTTableStyleInfo}
 
@@ -161,7 +160,7 @@ object Model2XlsxConversions extends BaseXlsx {
   }
 
   override def setTabColor(sheet: usermodel.Sheet, color: XSSFColor) {
-    sheet.asInstanceOf[SXSSFSheet].setTabColor(color)
+    sheet.asInstanceOf[XSSFSheet].setTabColor(color)
   }
 
   override def additionalPrintSetup(printSetup: PrintSetup, sheetPs: usermodel.PrintSetup) {

--- a/src/test/scala/com/norbitltd/spoiwo/natures/streaming/xlsx/ExportWorkbookStreamingSpec.scala
+++ b/src/test/scala/com/norbitltd/spoiwo/natures/streaming/xlsx/ExportWorkbookStreamingSpec.scala
@@ -1,0 +1,27 @@
+package com.norbitltd.spoiwo.natures.streaming.xlsx
+
+import java.io.ByteArrayOutputStream
+
+import com.norbitltd.spoiwo.model._
+import com.norbitltd.spoiwo.natures.streaming.xlsx.Model2XlsxConversions._
+import org.scalatest.{FlatSpec, Matchers}
+
+class ExportWorkbookStreamingSpec extends FlatSpec with Matchers {
+
+  "Writing workbook to an output stream" should "write non empty content" in {
+    val baos = new ByteArrayOutputStream()
+    Workbook(Sheet(name = "Test Sheet", rows = List.empty)).writeToOutputStream(baos)
+    baos.size() should be > 0
+  }
+
+  "Writing workbook to an output stream" should "fail if tables are set" in {
+    val baos = new ByteArrayOutputStream()
+    intercept[IllegalStateException] {
+      Workbook(Sheet(name = "Test Sheet", rows = List.empty, tables = List(Table(CellRange((1,1),(1,1)))))).writeToOutputStream(baos)
+    }
+
+    baos.size() should be (0)
+  }
+
+
+}

--- a/src/test/scala/com/norbitltd/spoiwo/natures/streaming/xlsx/Model2XlsxConversionsForCellStyleSpec.scala
+++ b/src/test/scala/com/norbitltd/spoiwo/natures/streaming/xlsx/Model2XlsxConversionsForCellStyleSpec.scala
@@ -1,0 +1,204 @@
+package com.norbitltd.spoiwo.natures.streaming.xlsx
+
+import com.norbitltd.spoiwo.model.Height._
+import com.norbitltd.spoiwo.model._
+import com.norbitltd.spoiwo.model.enums.{CellBorderStyle, CellFill, CellHorizontalAlignment, CellVerticalAlignment}
+import com.norbitltd.spoiwo.natures.streaming.xlsx.Model2XlsxConversions._
+import org.apache.poi.ss.usermodel.{BorderStyle, FillPatternType, HorizontalAlignment, VerticalAlignment}
+import org.apache.poi.xssf.streaming.SXSSFWorkbook
+import org.apache.poi.xssf.usermodel.{XSSFCellStyle, XSSFFont}
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.language.postfixOps
+
+class Model2XlsxConversionsForCellStyleSpec extends FlatSpec with Matchers {
+
+  val workbook = new SXSSFWorkbook()
+
+  "Cell style conversion" should "return no borders by default" in {
+    val modelDefault = CellStyle()
+    val xssfDefault = convertCellStyle(modelDefault, workbook)
+    xssfDefault.getBorderBottomEnum shouldBe BorderStyle.NONE
+    xssfDefault.getBorderLeftEnum shouldBe BorderStyle.NONE
+    xssfDefault.getBorderRightEnum shouldBe BorderStyle.NONE
+    xssfDefault.getBorderTopEnum shouldBe BorderStyle.NONE
+    xssfDefault.getBottomBorderXSSFColor shouldBe null
+    xssfDefault.getTopBorderXSSFColor shouldBe null
+    xssfDefault.getLeftBorderXSSFColor shouldBe null
+    xssfDefault.getRightBorderXSSFColor shouldBe null
+  }
+
+  it should "return explicitly set borders" in {
+    val modelBorders = CellBorders(leftStyle = CellBorderStyle.Double,
+                                   leftColor = Color.Blue,
+                                   rightStyle = CellBorderStyle.Thick,
+                                   rightColor = Color.Red)
+    val modelWithBorders = CellStyle(borders = modelBorders)
+    val xssfWithBorders = convertCellStyle(modelWithBorders, workbook)
+
+    xssfWithBorders.getBorderLeftEnum shouldBe BorderStyle.DOUBLE
+    xssfWithBorders.getBorderRightEnum shouldBe BorderStyle.THICK
+
+    val leftColorRGB = xssfWithBorders.getLeftBorderXSSFColor.getRGB
+    leftColorRGB.toList shouldBe List(0, 0, 255.toByte)
+    val rightColorRGB = xssfWithBorders.getRightBorderXSSFColor.getRGB
+    rightColorRGB.toList shouldBe List(255.toByte, 0, 0)
+  }
+
+  it should "return 'General' data format by default" in {
+    val modelDefault = CellStyle()
+    val xssfDefault = convertCellStyle(modelDefault, workbook)
+    xssfDefault.getDataFormatString shouldBe "General"
+  }
+
+  it should "return 'yyyy-MM-dd' data format when set explicitly" in {
+    val modelWithFormat = CellStyle(dataFormat = CellDataFormat("yyyy-MM-dd"))
+    val xssfWithFormat = convertCellStyle(modelWithFormat, workbook)
+    xssfWithFormat.getDataFormatString shouldBe "yyyy-MM-dd"
+  }
+
+  it should "return 11pt Calibri font by default" in {
+    val modelDefault = CellStyle()
+    val xssfDefault = convertCellStyle(modelDefault, workbook)
+    val xssfFont = xssfDefault.getFont
+    xssfFont.getFontName shouldBe "Calibri"
+    xssfFont.getFontHeightInPoints shouldBe 11
+  }
+
+  it should "return 14pt Arial when set explicitly" in {
+    val modelWithFont: CellStyle = CellStyle(font = Font(fontName = "Arial", height = 14 points))
+    val xssfWithFont: XSSFCellStyle = convertCellStyle(modelWithFont, workbook)
+    val xssfFont: XSSFFont = xssfWithFont.getFont
+    xssfFont.getFontName shouldBe "Arial"
+    xssfFont.getFontHeightInPoints shouldBe 14
+  }
+
+  it should "return no fill pattern by default" in {
+    val modelDefault = CellStyle()
+    val xssfDefault = convertCellStyle(modelDefault, workbook)
+    xssfDefault.getFillPatternEnum shouldBe FillPatternType.NO_FILL
+  }
+
+  it should "return 'Solid' fill pattern when explicitly set" in {
+    val modelWithFillPattern: CellStyle = CellStyle(fillPattern = CellFill.Solid)
+    val xssfWithFillPattern: XSSFCellStyle = convertCellStyle(modelWithFillPattern, workbook)
+    xssfWithFillPattern.getFillPatternEnum shouldBe FillPatternType.SOLID_FOREGROUND
+  }
+
+  it should "return no background or foreground color by default" in {
+    val modelDefault: CellStyle = CellStyle()
+    val xssfDefault: XSSFCellStyle = convertCellStyle(modelDefault, workbook)
+    xssfDefault.getFillForegroundXSSFColor shouldBe null
+    xssfDefault.getFillBackgroundXSSFColor shouldBe null
+  }
+
+  it should "return red background and blue foreground color when explicitly set" in {
+    val modelWithFillColors: CellStyle = CellStyle(fillBackgroundColor = Color.Red, fillForegroundColor = Color.Blue)
+    val xssfDefault: XSSFCellStyle = convertCellStyle(modelWithFillColors, workbook)
+    xssfDefault.getFillBackgroundXSSFColor.getRGB.toList shouldBe List(255.toByte, 0, 0)
+    xssfDefault.getFillForegroundXSSFColor.getRGB.toList shouldBe List(0, 0, 255.toByte)
+  }
+
+  it should "return 'General' horizontal alignment by default" in {
+    val modelDefault: CellStyle = CellStyle()
+    val xssfDefault: XSSFCellStyle = convertCellStyle(modelDefault, workbook)
+    xssfDefault.getAlignmentEnum shouldBe HorizontalAlignment.GENERAL
+  }
+
+  it should "return 'Right' horizontal alignment when explicitly set" in {
+    val modelWithHA: CellStyle = CellStyle(horizontalAlignment = CellHorizontalAlignment.Right)
+    val xssfWithHA: XSSFCellStyle = convertCellStyle(modelWithHA, workbook)
+    xssfWithHA.getAlignmentEnum shouldBe HorizontalAlignment.RIGHT
+  }
+
+  it should "return 'Bottom' vertical alignment by default" in {
+    val modelDefault: CellStyle = CellStyle()
+    val xssfDefault: XSSFCellStyle = convertCellStyle(modelDefault, workbook)
+    xssfDefault.getVerticalAlignmentEnum shouldBe VerticalAlignment.BOTTOM
+  }
+
+  it should "return 'Top' vertical alignment when explicitly set" in {
+    val modelWithVA: CellStyle = CellStyle(verticalAlignment = CellVerticalAlignment.Top)
+    val xssfWithVA: XSSFCellStyle = convertCellStyle(modelWithVA, workbook)
+    xssfWithVA.getVerticalAlignmentEnum shouldBe VerticalAlignment.TOP
+  }
+
+  it should "return not hidden cell style by default" in {
+    val modelDefault: CellStyle = CellStyle()
+    val xssfDefault: XSSFCellStyle = convertCellStyle(modelDefault, workbook)
+    xssfDefault.getHidden shouldBe false
+  }
+
+  it should "return not hidden cell style when explicitly set to false" in {
+    val model: CellStyle = CellStyle(hidden = false)
+    val xssf: XSSFCellStyle = convertCellStyle(model, workbook)
+    xssf.getHidden shouldBe false
+  }
+
+  it should "return hidden cell style when explicitly set to true" in {
+    val model: CellStyle = CellStyle(hidden = true)
+    val xssf: XSSFCellStyle = convertCellStyle(model, workbook)
+    xssf.getHidden shouldBe true
+  }
+
+  it should "return no indention by default" in {
+    val model: CellStyle = CellStyle()
+    val xssf: XSSFCellStyle = convertCellStyle(model, workbook)
+    xssf.getIndention shouldBe 0
+  }
+
+  it should "return indention of 4 spaces when explicitly set" in {
+    val model: CellStyle = CellStyle(indention = 4)
+    val xssf: XSSFCellStyle = convertCellStyle(model, workbook)
+    xssf.getIndention shouldBe 4
+  }
+
+  it should "return locked cell by default" in {
+    val model: CellStyle = CellStyle()
+    val xssf: XSSFCellStyle = convertCellStyle(model, workbook)
+    xssf.getLocked shouldBe true
+  }
+
+  it should "return unlocked cell when explicitly set to false" in {
+    val model: CellStyle = CellStyle(locked = false)
+    val xssf: XSSFCellStyle = convertCellStyle(model, workbook)
+    xssf.getLocked shouldBe false
+  }
+
+  it should "return locked cell when explicitly set to true" in {
+    val model: CellStyle = CellStyle(locked = true)
+    val xssf: XSSFCellStyle = convertCellStyle(model, workbook)
+    xssf.getLocked shouldBe true
+  }
+
+  it should "return no rotation by default" in {
+    val model: CellStyle = CellStyle()
+    val xssf: XSSFCellStyle = convertCellStyle(model, workbook)
+    xssf.getRotation shouldBe 0
+  }
+
+  it should "return 90 degree rotation if explicitly set" in {
+    val model: CellStyle = CellStyle(rotation = 90)
+    val xssf: XSSFCellStyle = convertCellStyle(model, workbook)
+    xssf.getRotation shouldBe 90
+  }
+
+  it should "return unwrapped text by default" in {
+    val model: CellStyle = CellStyle()
+    val xssf: XSSFCellStyle = convertCellStyle(model, workbook)
+    xssf.getWrapText shouldBe false
+  }
+
+  it should "return unwrapped text when explicitly set to false" in {
+    val model: CellStyle = CellStyle(wrapText = false)
+    val xssf: XSSFCellStyle = convertCellStyle(model, workbook)
+    xssf.getWrapText shouldBe false
+  }
+
+  it should "return wrapped text when explicitly set to true" in {
+    val model: CellStyle = CellStyle(wrapText = true)
+    val xssf: XSSFCellStyle = convertCellStyle(model, workbook)
+    xssf.getWrapText shouldBe true
+  }
+
+}

--- a/src/test/scala/com/norbitltd/spoiwo/natures/streaming/xlsx/Model2XlsxConversionsForRowSpec.scala
+++ b/src/test/scala/com/norbitltd/spoiwo/natures/streaming/xlsx/Model2XlsxConversionsForRowSpec.scala
@@ -1,0 +1,168 @@
+package com.norbitltd.spoiwo.natures.streaming.xlsx
+
+import com.norbitltd.spoiwo.model.Height._
+import com.norbitltd.spoiwo.model._
+import com.norbitltd.spoiwo.natures.streaming.xlsx.Model2XlsxConversions.convertRow
+import org.apache.poi.xssf.streaming.{SXSSFRow, SXSSFSheet, SXSSFWorkbook}
+import org.apache.poi.xssf.usermodel.{XSSFCellStyle, XSSFFont}
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.language.postfixOps
+import scala.util.Try
+
+class Model2XlsxConversionsForRowSpec extends FlatSpec with Matchers {
+
+  private def sheet: SXSSFSheet = new SXSSFWorkbook().createSheet()
+
+  private def convert(row: Row): SXSSFRow = convertRow(Map(), row, Sheet(), sheet)
+
+  private val defaultRow: SXSSFRow = convert(Row.Empty)
+
+  "Row conversion" should "return height of 15 points by default" in {
+    defaultRow.getHeightInPoints shouldBe 15
+    defaultRow.getHeight shouldBe 300
+  }
+
+  it should "return height of 13 point when set explicitly" in {
+    val model: Row = Row(height = 13 points)
+    val xlsx: SXSSFRow = convert(model)
+    xlsx.getHeightInPoints shouldBe 13
+    xlsx.getHeight shouldBe 260
+  }
+
+  it should "return no row style by default" in {
+    defaultRow.getRowStyle shouldBe null
+  }
+
+  it should "return 14pt Arial row style when set explicitly" in {
+    val model: Row = Row(style = CellStyle(font = Font(fontName = "Arial", height = 14 points)))
+    val xlsx: SXSSFRow = convert(model)
+
+    val font: XSSFFont = xlsx.getRowStyle.asInstanceOf[XSSFCellStyle].getFont
+    font.getFontHeightInPoints shouldBe 14
+    font.getFontName shouldBe "Arial"
+  }
+
+  it should "set unhidden row by default" in {
+    defaultRow.getZeroHeight shouldBe false
+  }
+
+  it should "set unhidden row when explicitly set to false" in {
+    val model: Row = Row(hidden = false)
+    val xlsx: SXSSFRow = convert(model)
+    xlsx.getZeroHeight shouldBe false
+  }
+
+  it should "set hidden row when explicitly set to true" in {
+    val model: Row = Row(hidden = true)
+    val xlsx: SXSSFRow = convert(model)
+    xlsx.getZeroHeight shouldBe true
+  }
+
+  it should "return row index of 0 for a single row in a sheet by default" in {
+    defaultRow.getRowNum shouldBe 0
+  }
+
+  it should "return row index of 2 for a single sheet with already 2 rows by default" in {
+    val sheetWithRows = sheet
+    sheetWithRows.createRow(0)
+    sheetWithRows.createRow(1)
+
+    val xlsx: SXSSFRow = convertRow(Map(), Row(), Sheet(), sheetWithRows)
+    xlsx.getRowNum shouldBe 2
+  }
+
+  it should "return index of 5 if the last row in the sheet has index of 4" in {
+    val sheetWithRows = sheet
+    sheetWithRows.createRow(4)
+
+    val xlsx: SXSSFRow = convertRow(Map(), Row(), Sheet(), sheetWithRows)
+    xlsx.getRowNum shouldBe 5
+  }
+
+  it should "have no cells by default" in {
+    defaultRow.cellIterator().hasNext shouldBe false
+  }
+
+  it should "correctly initialize one cell" in {
+    val cell: Cell = Cell("Test", style = CellStyle(font = Font(fontName = "Arial", height = 14 points)))
+    val model: Row = Row(cells = cell :: Nil)
+    val SXSSF: SXSSFRow = convert(model)
+
+    SXSSF.getFirstCellNum shouldBe 0
+    SXSSF.getLastCellNum shouldBe 1
+
+    val convertedFont = SXSSF.getCell(0).getCellStyle.asInstanceOf[XSSFCellStyle].getFont
+    convertedFont.getFontName shouldBe "Arial"
+    convertedFont.getFontHeightInPoints shouldBe 14
+  }
+
+  it should "correctly initialize multiple cells with no indexes" in {
+    val cell1: Cell = Cell("Test1", style = CellStyle(font = Font(fontName = "Arial", height = 14 points)))
+    val cell2: Cell = Cell("Test2", style = CellStyle(font = Font(fontName = "Arial", height = 16 points)))
+    val model: Row = Row(cells = cell1 :: cell2 :: Nil)
+    val SXSSF: SXSSFRow = convert(model)
+
+    SXSSF.getFirstCellNum shouldBe 0
+    SXSSF.getLastCellNum shouldBe 2
+
+    val convertedFont1 = SXSSF.getCell(0).getCellStyle.asInstanceOf[XSSFCellStyle].getFont
+    convertedFont1.getFontName shouldBe "Arial"
+    convertedFont1.getFontHeightInPoints shouldBe 14
+
+    val convertedFont2 = SXSSF.getCell(1).getCellStyle.asInstanceOf[XSSFCellStyle].getFont
+    convertedFont2.getFontName shouldBe "Arial"
+    convertedFont2.getFontHeightInPoints shouldBe 16
+  }
+
+  it should "correctly initialize single cell with index" in {
+    val cell = Cell("Test", index = 3)
+    val model: Row = Row(cells = cell :: Nil)
+    val SXSSF: SXSSFRow = convert(model)
+    SXSSF.getFirstCellNum shouldBe 3
+    SXSSF.getLastCellNum shouldBe 4
+
+    val SXSSFCell = SXSSF.getCell(3)
+    SXSSFCell.getStringCellValue shouldBe "Test"
+  }
+
+  it should "correctly initialize multiple cells with indexes" in {
+    val cell1 = Cell("Test1", index = 3)
+    val cell2 = Cell("Test2", index = 5)
+    val model: Row = Row(cells = cell1 :: cell2 :: Nil)
+    val SXSSF: SXSSFRow = convert(model)
+    SXSSF.getFirstCellNum shouldBe 3
+    SXSSF.getLastCellNum shouldBe 6
+
+    val SXSSFCell1 = SXSSF.getCell(3)
+    SXSSFCell1.getStringCellValue shouldBe "Test1"
+
+    val SXSSFCell2 = SXSSF.getCell(5)
+    SXSSFCell2.getStringCellValue shouldBe "Test2"
+  }
+
+  it should "fail when row has 2 cells with duplicate indexes" in {
+    val cell1 = Cell("Test1", index = 2)
+    val cell2 = Cell("Test2", index = 4)
+    val cell3 = Cell("Test3", index = 2)
+    val model: Row = Row(cells = cell1 :: cell2 :: cell3 :: Nil)
+
+    val converted = Try {
+
+      convert(model)
+    }
+    converted.isFailure shouldBe true
+  }
+
+  it should "fail when row has cells with and without explicit indexes" in {
+    val cell1 = Cell("Test1", index = 2)
+    val cell2 = Cell("Test2")
+    val model: Row = Row(cells = cell1 :: cell2 :: Nil)
+
+    val converted = Try {
+
+      convert(model)
+    }
+    converted.isFailure shouldBe true
+  }
+}

--- a/src/test/scala/com/norbitltd/spoiwo/natures/streaming/xlsx/Model2XlsxConversionsForSheetProperties.scala
+++ b/src/test/scala/com/norbitltd/spoiwo/natures/streaming/xlsx/Model2XlsxConversionsForSheetProperties.scala
@@ -1,0 +1,317 @@
+package com.norbitltd.spoiwo.natures.streaming.xlsx
+
+import com.norbitltd.spoiwo.model.Height._
+import com.norbitltd.spoiwo.model.{CellRange, SheetProperties}
+import com.norbitltd.spoiwo.natures.streaming.xlsx.Model2XlsxConversions.convertSheetProperties
+import org.apache.poi.ss.util.CellAddress
+import org.apache.poi.xssf.streaming.{SXSSFSheet, SXSSFWorkbook}
+import org.apache.poi.xssf.usermodel.XSSFWorkbook
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.language.postfixOps
+
+class Model2XlsxConversionsForSheetProperties extends FlatSpec with Matchers {
+
+  private def apply(properties: SheetProperties): SXSSFSheet = {
+    val sheet = new SXSSFWorkbook().createSheet()
+    convertSheetProperties(properties, sheet)
+    sheet
+  }
+
+  private val defaultSheet: SXSSFSheet = apply(SheetProperties())
+
+  "Sheet properties conversion" should "return no active cell by default" in {
+    defaultSheet.getActiveCell shouldBe null
+  }
+
+  it should "return B3 as active cell if explicitly specified" in {
+    val model = SheetProperties(activeCell = "B3")
+    val xssf = apply(model)
+    xssf.getActiveCell shouldBe new CellAddress("B3")
+  }
+
+  it should "return no auto-breaks by default" in {
+    defaultSheet.getAutobreaks shouldBe true
+  }
+
+  it should "return no auto-break when explicitly set to false" in {
+    val model = SheetProperties(autoBreaks = false)
+    val xssf = apply(model)
+    xssf.getAutobreaks shouldBe false
+  }
+
+  it should "return auto-breaks when explicitly set to true" in {
+    val model = SheetProperties(autoBreaks = true)
+    val xssf = apply(model)
+    xssf.getAutobreaks shouldBe true
+  }
+
+  it should "return 8 characters width by default" in {
+    defaultSheet.getDefaultColumnWidth shouldBe 8
+  }
+
+  it should "return 12 characters width when set explicitly" in {
+    val model = SheetProperties(defaultColumnWidth = 12)
+    val xssf = apply(model)
+    xssf.getDefaultColumnWidth shouldBe 12
+  }
+
+  it should "return 15 points height by default" in {
+    defaultSheet.getDefaultRowHeightInPoints shouldBe 15
+    defaultSheet.getDefaultRowHeight shouldBe 300
+  }
+
+  it should "return 20 points height when set explicitly" in {
+    val model = SheetProperties(defaultRowHeight = 20 points)
+    val xssf = apply(model)
+    xssf.getDefaultRowHeightInPoints shouldBe 20
+    xssf.getDefaultRowHeight shouldBe 400
+  }
+
+  it should "return no display formulas by default" in {
+    defaultSheet.isDisplayFormulas shouldBe false
+  }
+
+  it should "return no display formulas when set to false" in {
+    val model = SheetProperties(displayFormulas = false)
+    val xssf = apply(model)
+    xssf.isDisplayFormulas shouldBe false
+  }
+
+  it should "return display formulas when set to true" in {
+    val model = SheetProperties(displayFormulas = true)
+    val xssf = apply(model)
+    xssf.isDisplayFormulas shouldBe true
+  }
+
+  it should "return display grid lines by default" in {
+    defaultSheet.isDisplayGridlines shouldBe true
+  }
+
+  it should "return no display grid lines when set to false" in {
+    val model = SheetProperties(displayGridLines = false)
+    val xssf = apply(model)
+    xssf.isDisplayGridlines shouldBe false
+  }
+
+  it should "return display grid lines when set to true" in {
+    val model = SheetProperties(displayGridLines = true)
+    val xssf = apply(model)
+    xssf.isDisplayGridlines shouldBe true
+  }
+
+  it should "return display guts by default" in {
+    defaultSheet.getDisplayGuts shouldBe true
+  }
+
+  it should "return no display guts when set to false" in {
+    val model = SheetProperties(displayGuts = false)
+    val xssf = apply(model)
+    xssf.getDisplayGuts shouldBe false
+  }
+
+  it should "return display guts when set to true" in {
+    val model = SheetProperties(displayGuts = true)
+    val xssf = apply(model)
+    xssf.getDisplayGuts shouldBe true
+  }
+
+  it should "return display row/column headings by default" in {
+    defaultSheet.isDisplayRowColHeadings shouldBe true
+  }
+
+  it should "return no display row/column headings when set to false" in {
+    val model = SheetProperties(displayRowColHeadings = false)
+    val xssf = apply(model)
+    xssf.isDisplayRowColHeadings shouldBe false
+  }
+
+  it should "return display row/column headings when set to true" in {
+    val model = SheetProperties(displayRowColHeadings = true)
+    val xssf = apply(model)
+    xssf.isDisplayRowColHeadings shouldBe true
+  }
+
+  it should "return display zeros by default" in {
+    defaultSheet.isDisplayZeros shouldBe true
+  }
+
+  it should "return no display zeros when set to false" in {
+    val model = SheetProperties(displayZeros = false)
+    val xssf = apply(model)
+    xssf.isDisplayZeros shouldBe false
+  }
+
+  it should "return display zeros when set to true" in {
+    val model = SheetProperties(displayZeros = true)
+    val xssf = apply(model)
+    xssf.isDisplayZeros shouldBe true
+  }
+
+  it should "not fit sheet to page by default" in {
+    defaultSheet.getFitToPage shouldBe false
+  }
+
+  it should "not fit sheet to page when set to false" in {
+    val model = SheetProperties(fitToPage = false)
+    val xssf = apply(model)
+    xssf.getFitToPage shouldBe false
+  }
+
+  it should "fit sheet to page when set to true" in {
+    val model = SheetProperties(fitToPage = true)
+    val xssf = apply(model)
+    xssf.getFitToPage shouldBe true
+  }
+
+  it should "not force formula recalculation by default" in {
+    defaultSheet.getForceFormulaRecalculation shouldBe false
+  }
+
+  it should "not force formula recalculation when set to false" in {
+    val model = SheetProperties(forceFormulaRecalculation = false)
+    val xssf = apply(model)
+    xssf.getForceFormulaRecalculation shouldBe false
+  }
+
+  it should "force formula recalculation when set to true" in {
+    val model = SheetProperties(forceFormulaRecalculation = true)
+    val xssf = apply(model)
+    xssf.getForceFormulaRecalculation shouldBe true
+  }
+
+  it should "not get horizontally center by default" in {
+    defaultSheet.getHorizontallyCenter shouldBe false
+  }
+
+  it should "not get horizontally center when set to false" in {
+    val model = SheetProperties(horizontallyCenter = false)
+    val xssf = apply(model)
+    xssf.getHorizontallyCenter shouldBe false
+  }
+
+  it should "get horizontally center when set to true" in {
+    val model = SheetProperties(horizontallyCenter = true)
+    val xssf = apply(model)
+    xssf.getHorizontallyCenter shouldBe true
+  }
+
+  it should "not return the print area by default" in {
+    defaultSheet.getWorkbook.getPrintArea(0) shouldBe null
+  }
+
+  it should "return the print area  when set explicitly" in {
+    val model = SheetProperties(printArea = CellRange(2 -> 7, 1 -> 4))
+    val xssf = apply(model)
+    xssf.getWorkbook.getPrintArea(0) shouldBe "Sheet0!$B$3:$E$8"
+  }
+
+  it should "print grid lines by default" in {
+    defaultSheet.isPrintGridlines shouldBe false
+  }
+
+  it should "not print grid lines when set to false" in {
+    val model = SheetProperties(printGridLines = false)
+    val xssf = apply(model)
+    xssf.isPrintGridlines shouldBe false
+  }
+
+  it should "get print grid lines when set to true" in {
+    val model = SheetProperties(printGridLines = true)
+    val xssf = apply(model)
+    xssf.isPrintGridlines shouldBe true
+  }
+
+  it should "not be right to left by default" in {
+    defaultSheet.isRightToLeft shouldBe false
+  }
+
+  it should "not be right to left when set to false" in {
+    val model = SheetProperties(rightToLeft = false)
+    val xssf = apply(model)
+    xssf.isRightToLeft shouldBe false
+  }
+
+  it should "be right to left when set to true" in {
+    val model = SheetProperties(rightToLeft = true)
+    val xssf = apply(model)
+    xssf.isRightToLeft shouldBe true
+  }
+
+  it should "do row sums below by default" in {
+    defaultSheet.getRowSumsBelow shouldBe true
+  }
+
+  it should "not do row sums below when set to false" in {
+    val model = SheetProperties(rowSumsBelow = false)
+    val xssf = apply(model)
+    xssf.getRowSumsBelow shouldBe false
+  }
+
+  it should "be do row sums below when set to true" in {
+    val model = SheetProperties(rowSumsBelow = true)
+    val xssf = apply(model)
+    xssf.getRowSumsBelow shouldBe true
+  }
+
+  it should "do row sums right by default" in {
+    defaultSheet.getRowSumsRight shouldBe true
+  }
+
+  it should "not do row sums right when set to false" in {
+    val model = SheetProperties(rowSumsRight = false)
+    val xssf = apply(model)
+    xssf.getRowSumsRight shouldBe false
+  }
+
+  it should "be do row sums right when set to true" in {
+    val model = SheetProperties(rowSumsRight = true)
+    val xssf = apply(model)
+    xssf.getRowSumsRight shouldBe true
+  }
+
+  it should "be selected by default when only 1 sheet" in {
+    defaultSheet.isSelected shouldBe true
+  }
+
+  it should "not be selected when set to false, but only one sheet" in {
+    val model = SheetProperties(selected = false)
+    val xssf = apply(model)
+    xssf.isSelected shouldBe false
+  }
+
+  it should "not be selected when set to false, but there are multiple sheets" in {
+    val workbook = new XSSFWorkbook()
+    val sheet1 = workbook.createSheet("S1")
+    val sheet2 = workbook.createSheet("S2")
+    val model1 = SheetProperties(selected = false)
+    val model2 = SheetProperties(selected = true)
+    convertSheetProperties(model1, sheet1)
+    convertSheetProperties(model2, sheet2)
+    sheet1.isSelected shouldBe false
+    sheet2.isSelected shouldBe true
+  }
+
+  it should "be selected when set to true" in {
+    val model = SheetProperties(selected = true)
+    val xssf = apply(model)
+    xssf.isSelected shouldBe true
+  }
+
+  it should "not be virtually center by default" in {
+    defaultSheet.getVerticallyCenter shouldBe false
+  }
+
+  it should "not be virtually center when set to false" in {
+    val model = SheetProperties(virtuallyCenter = false)
+    val xssf = apply(model)
+    xssf.getVerticallyCenter shouldBe false
+  }
+
+  it should "be virtually center when set to true" in {
+    val model = SheetProperties(virtuallyCenter = true)
+    val xssf = apply(model)
+    xssf.getVerticallyCenter shouldBe true
+  }
+
+}

--- a/src/test/scala/com/norbitltd/spoiwo/natures/streaming/xlsx/Model2XlsxConversionsForSheetSpec.scala
+++ b/src/test/scala/com/norbitltd/spoiwo/natures/streaming/xlsx/Model2XlsxConversionsForSheetSpec.scala
@@ -48,6 +48,19 @@ class Model2XlsxConversionsForSheetSpec extends FlatSpec with Matchers {
     nonEqualCells(existingPoiSheet, dataMatrix, _.getStringCellValue) shouldBe empty
   }
 
+  it should "write to existing sheet by overwriting existing cells and custom print setup" in {
+    val w: SXSSFWorkbook = workbook
+    w.createSheet("Existing")
+    val previousSheet = generateSheet(0 to 2, 0 to 5)
+    val existingPoiSheet: SXSSFSheet= convertSheet(previousSheet, w)
+    val newSheet = generateSheet[Int, Int](1 to 3, 1 to 4, (rowNum, colNum) => s"NEW $colNum,$rowNum").copy(
+      printSetup = Some(PrintSetup(10, true, 1000))
+    )
+    writeToExistingSheet(newSheet, existingPoiSheet)
+    val dataMatrix = mergeSheetData(Seq(previousSheet, newSheet), _.value.toString)
+    nonEqualCells(existingPoiSheet, dataMatrix, _.getStringCellValue) shouldBe empty
+  }
+
   it should "fail if there is an attempt to modify an existing cell" in {
     val inputStream = this.getClass.getResourceAsStream("/with_formula.xlsx")
     val w = new SXSSFWorkbook(XSSFWorkbookFactory.createWorkbook(inputStream))

--- a/src/test/scala/com/norbitltd/spoiwo/natures/streaming/xlsx/Model2XlsxConversionsForSheetSpec.scala
+++ b/src/test/scala/com/norbitltd/spoiwo/natures/streaming/xlsx/Model2XlsxConversionsForSheetSpec.scala
@@ -1,0 +1,195 @@
+package com.norbitltd.spoiwo.natures.streaming.xlsx
+
+import com.norbitltd.spoiwo.model.Height._
+import com.norbitltd.spoiwo.model.Width._
+import com.norbitltd.spoiwo.model._
+import com.norbitltd.spoiwo.natures.streaming.xlsx.Model2XlsxConversions.{convertSheet, writeToExistingSheet}
+import com.norbitltd.spoiwo.natures.xlsx.Utils._
+import org.apache.poi.xssf.streaming.{SXSSFSheet, SXSSFWorkbook}
+import org.apache.poi.xssf.usermodel.{XSSFCellStyle, XSSFWorkbookFactory}
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.language.postfixOps
+
+class Model2XlsxConversionsForSheetSpec extends FlatSpec with Matchers {
+
+  private def workbook = new SXSSFWorkbook()
+
+  private def convert(s: Sheet): SXSSFSheet = convertSheet(s, workbook)
+
+  private def defaultSheet = convert(Sheet())
+
+  "Sheet conversions" should "set sheet name to 'Sheet1' by default in empty workbook" in {
+    defaultSheet.getSheetName shouldBe "Sheet1"
+  }
+
+  it should "set sheet name to 'Sheet 3'in a workbook with already 2 sheets defined" in {
+    val w: SXSSFWorkbook = workbook
+    w.createSheet("Test1")
+    w.createSheet("Test2")
+    val sheet3: SXSSFSheet= convertSheet(Sheet(), w)
+    sheet3.getSheetName shouldBe "Sheet3"
+  }
+
+  it should "return defined name when set explicitly" in {
+    val model = Sheet(name = "My Name")
+    val xssf = convert(model)
+    xssf.getSheetName shouldBe "My Name"
+  }
+
+  it should "write to existing sheet by overwriting existing cells" in {
+    val w: SXSSFWorkbook = workbook
+    w.createSheet("Existing")
+    val previousSheet = generateSheet(0 to 2, 0 to 5)
+    val existingPoiSheet: SXSSFSheet= convertSheet(previousSheet, w)
+    val newSheet = generateSheet[Int, Int](1 to 3, 1 to 4, (rowNum, colNum) => s"NEW $colNum,$rowNum")
+    writeToExistingSheet(newSheet, existingPoiSheet)
+    val dataMatrix = mergeSheetData(Seq(previousSheet, newSheet), _.value.toString)
+    nonEqualCells(existingPoiSheet, dataMatrix, _.getStringCellValue) shouldBe empty
+  }
+
+  it should "fail if there is an attempt to modify an existing cell" in {
+    val inputStream = this.getClass.getResourceAsStream("/with_formula.xlsx")
+    val w = new SXSSFWorkbook(XSSFWorkbookFactory.createWorkbook(inputStream))
+    w.getXSSFWorkbook.getCalculationChain.getCTCalcChain.sizeOfCArray() should equal(1)
+    val existingPoiSheet = w.getSheetAt(0)
+    val newSheet = Sheet(Row(Seq(Cell(2.0, index = 0)), index = 0))
+
+    /*
+    This isn't supported at the moment: https://poi.apache.org/apidocs/dev/org/apache/poi/xssf/streaming/SXSSFWorkbook.html#SXSSFWorkbook-org.apache.poi.xssf.usermodel.XSSFWorkbook-
+    https://stackoverflow.com/questions/30868325/apache-poi-getrow-returns-null-and-createrow-fails
+     */
+    intercept[IllegalArgumentException] {
+      writeToExistingSheet(newSheet, existingPoiSheet)
+    }
+  }
+
+  it should "Access initial cells and rows in the template. After constructing all internal windows are empty and SXSSFSheet.getRow(int) and SXSSFRow.getCell(int) return null" in {
+    val inputStream = this.getClass.getResourceAsStream("/with_formula.xlsx")
+    val w = new SXSSFWorkbook(XSSFWorkbookFactory.createWorkbook(inputStream))
+    w.getXSSFWorkbook.getCalculationChain.getCTCalcChain.sizeOfCArray() should equal(1)
+    val existingPoiSheet = w.getSheetAt(0)
+
+    existingPoiSheet.getRow(0) should be(null)
+  }
+
+  it should "not have 1st column style by default" in {
+    val xssfFont = defaultSheet.getColumnStyle(0).asInstanceOf[XSSFCellStyle].getFont
+    xssfFont.getFontName shouldBe "Calibri"
+    xssfFont.getFontHeightInPoints shouldBe 11
+  }
+
+  it should "have 1st column width when set with column without index" in {
+    val model = Sheet(columns = Column(width = 200 unitsOfWidth) :: Nil)
+    val xssf = convert(model)
+    xssf.getColumnWidth(0) shouldBe 200
+  }
+
+  it should "have correct 1st and 2nd column style when set with column without index" in {
+    val column1 = Column(width = 200 unitsOfWidth)
+    val column2 = Column(width = 300 unitsOfWidth)
+    val model = Sheet(columns = column1 :: column2 :: Nil)
+    val xssf = convert(model)
+
+    xssf.getColumnWidth(0) shouldBe 200
+    xssf.getColumnWidth(1) shouldBe 300
+  }
+
+  it should "have 3rd column style when set with column with index" in {
+    val model = Sheet(columns = Column(width = 300 unitsOfWidth, index = 2) :: Nil)
+    val xssf = convert(model)
+    xssf.getColumnWidth(2) shouldBe 300
+  }
+
+  it should "have correct 4th and 6th column style when set with column without index" in {
+    val column1 = Column(width = 200 unitsOfWidth, index = 3)
+    val column2 = Column(width = 300 unitsOfWidth, index = 5)
+    val model = Sheet(columns = column1 :: column2 :: Nil)
+    val xssf = convert(model)
+
+    xssf.getColumnWidth(3) shouldBe 200
+    xssf.getColumnWidth(4) shouldBe (8 characters).toUnits
+    xssf.getColumnWidth(5) shouldBe 300
+  }
+
+  it should "not allow mixing columns with and without index" in {
+    val column1 = Column(style = CellStyle(font = Font(fontName = "Arial", height = 14 points)))
+    val column2 = Column(style = CellStyle(font = Font(fontName = "Arial", height = 16 points)), index = 5)
+    val model = Sheet(columns = column1 :: column2 :: Nil)
+    an[IllegalArgumentException] should be thrownBy convert(model)
+  }
+
+  it should "not allow 2 columns with the same index" in {
+    val column1 = Column(style = CellStyle(font = Font(fontName = "Arial", height = 14 points)), index = 3)
+    val column2 = Column(style = CellStyle(font = Font(fontName = "Arial", height = 16 points)), index = 5)
+    val column3 = Column(style = CellStyle(font = Font(fontName = "Arial", height = 16 points)), index = 3)
+    val model = Sheet(columns = column1 :: column2 :: column3 :: Nil)
+    an[IllegalArgumentException] should be thrownBy convert(model)
+  }
+
+  it should "have no rows by default" in {
+    defaultSheet.rowIterator().hasNext shouldBe false
+  }
+
+  it should "have 1st row with initialized with row and without index" in {
+    val row = Row().withCellValues("Test", 34)
+    val model = Sheet(rows = row :: Nil)
+
+    val xlsx = convert(model)
+    val xlsxRow = xlsx.getRow(0)
+    xlsxRow.getCell(0).getStringCellValue shouldBe "Test"
+    xlsxRow.getCell(1).getNumericCellValue shouldBe 34
+  }
+
+  it should "have 1st and 2nd row with initialized with row and without index" in {
+    val row1 = Row().withCellValues("Test", 34)
+    val row2 = Row().withCellValues("OK")
+    val model = Sheet(rows = row1 :: row2 :: Nil)
+
+    val xlsx = convert(model)
+    val xlsxRow1 = xlsx.getRow(0)
+    val xlsxRow2 = xlsx.getRow(1)
+    xlsxRow1.getCell(0).getStringCellValue shouldBe "Test"
+    xlsxRow1.getCell(1).getNumericCellValue shouldBe 34
+    xlsxRow2.getCell(0).getStringCellValue shouldBe "OK"
+  }
+
+  it should "have 3rd row with initialized with row with index" in {
+    val row = Row(index = 2).withCellValues("Test", 34)
+    val model = Sheet(rows = row :: Nil)
+
+    val xlsx = convert(model)
+    val xlsxRow = xlsx.getRow(2)
+    xlsxRow.getCell(0).getStringCellValue shouldBe "Test"
+    xlsxRow.getCell(1).getNumericCellValue shouldBe 34
+  }
+
+  it should "have 3rd and 5th row with initialized with row and index" in {
+    val row1 = Row(index = 4).withCellValues("Test", 34)
+    val row2 = Row(index = 6).withCellValues("OK")
+    val model = Sheet(rows = row1 :: row2 :: Nil)
+
+    val xlsx = convert(model)
+    val xlsxRow1 = xlsx.getRow(4)
+    val xlsxRow2 = xlsx.getRow(6)
+    xlsxRow1.getCell(0).getStringCellValue shouldBe "Test"
+    xlsxRow1.getCell(1).getNumericCellValue shouldBe 34
+    xlsxRow2.getCell(0).getStringCellValue shouldBe "OK"
+  }
+
+  it should "not allow duplicate row indexes" in {
+    val row1 = Row(index = 4).withCellValues("Test", 34)
+    val row2 = Row(index = 6).withCellValues("OK")
+    val row3 = Row(index = 4).withCellValues("Override")
+    val model = Sheet(rows = row1 :: row2 :: row3 :: Nil)
+    an[IllegalArgumentException] should be thrownBy convert(model)
+  }
+
+  it should "not allow mixing indexed and non indexed rows" in {
+    val row1 = Row(index = 4).withCellValues("Test", 34)
+    val row2 = Row().withCellValues("OK")
+    val model = Sheet(rows = row1 :: row2 :: Nil)
+    an[IllegalArgumentException] should be thrownBy convert(model)
+  }
+
+}

--- a/src/test/scala/com/norbitltd/spoiwo/natures/streaming/xlsx/Model2XlsxConversionsForWorkbookCacheSpec.scala
+++ b/src/test/scala/com/norbitltd/spoiwo/natures/streaming/xlsx/Model2XlsxConversionsForWorkbookCacheSpec.scala
@@ -1,0 +1,51 @@
+package com.norbitltd.spoiwo.natures.streaming.xlsx
+
+import java.lang.reflect.Field
+
+import com.norbitltd.spoiwo.model.Height._
+import com.norbitltd.spoiwo.model._
+import Model2XlsxConversions._
+import org.apache.poi.xssf.streaming.SXSSFWorkbook
+import org.scalatest.{FlatSpec, Matchers}
+
+import scala.language.postfixOps
+import scala.util.Try
+
+class Model2XlsxConversionsForWorkbookCacheSpec extends FlatSpec with Matchers {
+
+  private val style = CellStyle(
+    font = Font(height = 24 points, fontName = "Courier New", italic = true, strikeout = true),
+    dataFormat = CellDataFormat("0.0")
+  )
+
+  private val victim = Workbook(
+    Sheet(name = "Test Sheet", rows = List(Row(Seq(Cell("1", style = style), Cell("2", style = style)))))
+  )
+
+  private val conversions = Model2XlsxConversions
+
+  private val cellStyleCacheField: Field = getConversionsField("cellStyleCache")
+  cellStyleCacheField.setAccessible(true)
+  private val dataFormatCacheField: Field = getConversionsField("dataFormatCache")
+  dataFormatCacheField.setAccessible(true)
+  private val fontCacheField: Field = getConversionsField("fontCache")
+  fontCacheField.setAccessible(true)
+
+  "Cached workbook " should "be removed from cache after conversion" in {
+    assertNotCached(victim.convertAsXlsx())
+  }
+
+  //Workaround for the scala/2.11 compiler which messes up with the private variable names
+  private def getConversionsField(name: String): Field = Try(conversions.getClass.getDeclaredField(name)).getOrElse {
+    val allFields = conversions.getClass.getDeclaredFields
+    allFields.filter(_.getName contains name).head
+  }
+
+  private def assertNotCached(workbook: SXSSFWorkbook) {
+    def getValue(field: Field) = field.get(conversions).asInstanceOf[collection.mutable.Map[SXSSFWorkbook, _]]
+    getValue(cellStyleCacheField).keySet should not contain workbook
+    getValue(dataFormatCacheField).keySet should not contain workbook
+    getValue(fontCacheField).keySet should not contain workbook
+  }
+
+}

--- a/src/test/scala/com/norbitltd/spoiwo/natures/streaming/xlsx/Model2XlsxConversionsForWorkbookStreamingSpec.scala
+++ b/src/test/scala/com/norbitltd/spoiwo/natures/streaming/xlsx/Model2XlsxConversionsForWorkbookStreamingSpec.scala
@@ -52,11 +52,11 @@ class Model2XlsxConversionsForWorkbookStreamingSpec extends FlatSpec with Matche
     existingWorkbook.getSheetAt(2).getSheetName shouldBe "New"
     val overwrittenPoiSheet = existingWorkbook.getSheet("Overwrite")
     val overwrittenSheetData = mergeSheetData(Seq(previousSheet, overwritingSheet), _.value.toString)
-    nonEqualCellsStreaming(overwrittenPoiSheet, overwrittenSheetData, _.getStringCellValue) shouldBe empty
+    nonEqualCells(overwrittenPoiSheet, overwrittenSheetData, _.getStringCellValue) shouldBe empty
     val untouchedSheetData = mergeSheetData(Seq(untouchedSheet), _.value.toString)
-    nonEqualCellsStreaming(existingWorkbook.getSheet("Untouched"), untouchedSheetData, _.getStringCellValue) shouldBe empty
+    nonEqualCells(existingWorkbook.getSheet("Untouched"), untouchedSheetData, _.getStringCellValue) shouldBe empty
     val newSheetData = mergeSheetData(Seq(newSheet), _.value.toString)
-    nonEqualCellsStreaming(existingWorkbook.getSheet("New"), newSheetData, _.getStringCellValue) shouldBe empty
+    nonEqualCells(existingWorkbook.getSheet("New"), newSheetData, _.getStringCellValue) shouldBe empty
   }
 
   it should "return first sheet as active sheet by default" in {

--- a/src/test/scala/com/norbitltd/spoiwo/natures/streaming/xlsx/Model2XlsxConversionsForWorkbookStreamingSpec.scala
+++ b/src/test/scala/com/norbitltd/spoiwo/natures/streaming/xlsx/Model2XlsxConversionsForWorkbookStreamingSpec.scala
@@ -1,0 +1,82 @@
+package com.norbitltd.spoiwo.natures.streaming.xlsx
+
+import com.norbitltd.spoiwo.model.{Sheet, Workbook}
+import com.norbitltd.spoiwo.natures.streaming.xlsx.Model2XlsxConversions.{convertWorkbook, writeToExistingWorkbook}
+import com.norbitltd.spoiwo.natures.xlsx.Utils._
+import org.apache.poi.xssf.streaming.SXSSFWorkbook
+import org.scalatest.{FlatSpec, Matchers}
+
+class Model2XlsxConversionsForWorkbookStreamingSpec extends FlatSpec with Matchers {
+
+  def defaultWorkbook = Workbook(
+    Sheet(name = "Sheet 1"),
+    Sheet(name = "Sheet 2")
+  )
+
+  val default: SXSSFWorkbook = convertWorkbook(defaultWorkbook)
+
+  "Workbook conversion" should "return a workbook with 1 sheet when default converted" in {
+    default.getNumberOfSheets shouldBe 2
+    default.getSheetAt(0).getSheetName shouldBe "Sheet 1"
+  }
+
+  it should "convert all the sheets provided in order" in {
+    val model = Workbook(
+      Sheet(name = "Jeden"),
+      Sheet(name = "Dwa"),
+      Sheet(name = "Trzy")
+    )
+    val xlsx = convertWorkbook(model)
+    xlsx.getNumberOfSheets shouldBe 3
+    xlsx.getSheetAt(0).getSheetName shouldBe "Jeden"
+    xlsx.getSheetAt(1).getSheetName shouldBe "Dwa"
+    xlsx.getSheetAt(2).getSheetName shouldBe "Trzy"
+  }
+
+  it should "be able to merge sheets into existing workbook" in {
+    val previousSheet = generateSheet(0 to 2, 0 to 5).withSheetName("Overwrite")
+    val untouchedSheet = generateSheet(0 to 3, 0 to 5).withSheetName("Untouched")
+    val previousModel = Workbook(previousSheet, untouchedSheet)
+    val existingWorkbook = convertWorkbook(previousModel)
+    val overwritingSheet =
+      generateSheet[Int, Int](1 to 3, 1 to 4, (rowNum, colNum) => s"NEW $colNum,$rowNum").withSheetName("Overwrite")
+    val newSheet = generateSheet(0 to 3, 0 to 5).withSheetName("New")
+    val newModel = Workbook(
+      overwritingSheet,
+      newSheet
+    )
+    writeToExistingWorkbook(newModel, existingWorkbook)
+    existingWorkbook.getNumberOfSheets shouldBe 3
+    existingWorkbook.getSheetAt(0).getSheetName shouldBe "Overwrite"
+    existingWorkbook.getSheetAt(1).getSheetName shouldBe "Untouched"
+    existingWorkbook.getSheetAt(2).getSheetName shouldBe "New"
+    val overwrittenPoiSheet = existingWorkbook.getSheet("Overwrite")
+    val overwrittenSheetData = mergeSheetData(Seq(previousSheet, overwritingSheet), _.value.toString)
+    nonEqualCellsStreaming(overwrittenPoiSheet, overwrittenSheetData, _.getStringCellValue) shouldBe empty
+    val untouchedSheetData = mergeSheetData(Seq(untouchedSheet), _.value.toString)
+    nonEqualCellsStreaming(existingWorkbook.getSheet("Untouched"), untouchedSheetData, _.getStringCellValue) shouldBe empty
+    val newSheetData = mergeSheetData(Seq(newSheet), _.value.toString)
+    nonEqualCellsStreaming(existingWorkbook.getSheet("New"), newSheetData, _.getStringCellValue) shouldBe empty
+  }
+
+  it should "return first sheet as active sheet by default" in {
+    default.getActiveSheetIndex shouldBe 0
+  }
+
+  it should "return stated sheet as active sheet when explicitly set" in {
+    val model = defaultWorkbook.withActiveSheet(1)
+    val xlsx = convertWorkbook(model)
+    xlsx.getActiveSheetIndex shouldBe 1
+  }
+
+  it should "return first visible tab for first sheet by default" in {
+    default.getFirstVisibleTab shouldBe 0
+  }
+
+  it should "return first visible tab for the 2nd sheet when set explicitly" in {
+    val model = defaultWorkbook.withFirstVisibleTab(1)
+    val xlsx = convertWorkbook(model)
+    xlsx.getFirstVisibleTab shouldBe 1
+  }
+
+}

--- a/src/test/scala/com/norbitltd/spoiwo/natures/xlsx/Utils.scala
+++ b/src/test/scala/com/norbitltd/spoiwo/natures/xlsx/Utils.scala
@@ -2,6 +2,7 @@ package com.norbitltd.spoiwo.natures.xlsx
 
 import com.norbitltd.spoiwo.model.{Cell, HasIndex, Row, Sheet}
 import HasIndex._
+import org.apache.poi.xssf.streaming.{SXSSFCell, SXSSFSheet}
 import org.apache.poi.xssf.usermodel.{XSSFCell, XSSFSheet}
 
 import scala.reflect.ClassTag
@@ -30,6 +31,21 @@ object Utils {
   }
 
   def nonEqualCells[T](sheet: XSSFSheet, data: Array[Array[T]], extractor: XSSFCell => T)(implicit ev: Null <:< T): Seq[(T, T)] = {
+    data.zipWithIndex.flatMap {
+      case (dataRow, rowIdx) =>
+        dataRow.zipWithIndex.flatMap {
+          case (expectedData, cellIdx) =>
+            val actualData = for {
+              row <- Option(sheet.getRow(rowIdx))
+              cell <- Option(row.getCell(cellIdx))
+            } yield extractor(cell)
+            if (actualData.orNull[T] == expectedData) Nil
+            else List((actualData.orNull[T], expectedData))
+        }
+    }.toSeq
+  }
+
+  def nonEqualCellsStreaming[T](sheet: SXSSFSheet, data: Array[Array[T]], extractor: SXSSFCell => T)(implicit ev: Null <:< T): Seq[(T, T)] = {
     data.zipWithIndex.flatMap {
       case (dataRow, rowIdx) =>
         dataRow.zipWithIndex.flatMap {

--- a/src/test/scala/com/norbitltd/spoiwo/natures/xlsx/Utils.scala
+++ b/src/test/scala/com/norbitltd/spoiwo/natures/xlsx/Utils.scala
@@ -1,9 +1,8 @@
 package com.norbitltd.spoiwo.natures.xlsx
 
-import com.norbitltd.spoiwo.model.{Cell, HasIndex, Row, Sheet}
-import HasIndex._
-import org.apache.poi.xssf.streaming.{SXSSFCell, SXSSFSheet}
-import org.apache.poi.xssf.usermodel.{XSSFCell, XSSFSheet}
+import com.norbitltd.spoiwo.model.HasIndex._
+import com.norbitltd.spoiwo.model.{Cell, Row, Sheet}
+import org.apache.poi.ss.usermodel
 
 import scala.reflect.ClassTag
 
@@ -30,22 +29,7 @@ object Utils {
     dataMatrix
   }
 
-  def nonEqualCells[T](sheet: XSSFSheet, data: Array[Array[T]], extractor: XSSFCell => T)(implicit ev: Null <:< T): Seq[(T, T)] = {
-    data.zipWithIndex.flatMap {
-      case (dataRow, rowIdx) =>
-        dataRow.zipWithIndex.flatMap {
-          case (expectedData, cellIdx) =>
-            val actualData = for {
-              row <- Option(sheet.getRow(rowIdx))
-              cell <- Option(row.getCell(cellIdx))
-            } yield extractor(cell)
-            if (actualData.orNull[T] == expectedData) Nil
-            else List((actualData.orNull[T], expectedData))
-        }
-    }.toSeq
-  }
-
-  def nonEqualCellsStreaming[T](sheet: SXSSFSheet, data: Array[Array[T]], extractor: SXSSFCell => T)(implicit ev: Null <:< T): Seq[(T, T)] = {
+  def nonEqualCells[T](sheet: usermodel.Sheet, data: Array[Array[T]], extractor: usermodel.Cell => T)(implicit ev: Null <:< T): Seq[(T, T)] = {
     data.zipWithIndex.flatMap {
       case (dataRow, rowIdx) =>
         dataRow.zipWithIndex.flatMap {


### PR DESCRIPTION
Trying to enable SXSSF with spoiwo I used most of the code  from Model2XslxConversions as SXSSF is mostly a wrapper around XSSF
Things that don't work:

- Writing or accessing  existing cells from a template
- createTable is not available in SXSSFSheet
- Odd and Even headers and footers are not available in SXSSFSheet 

Most of the tests are from xlsx using xssf, just changed imports and type definitions to validate that things still worked.

As there was too many duplicated code (I started with a full copy of Model2XlsxConversions), I created a base trait with shared functionality, not sure if this is the recommended way to go.

Can you please give me some feedback?

Thank you.