### PR TITLE
POI 5.4.1 upgrade due to CVE-2025-31672

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Spoiwo is available in [The Central Repository](https://search.maven.org/#search
 
 ```
 libraryDependencies ++= Seq(
-  "com.norbitltd" %% "spoiwo" % "2.2.1"
+  "com.norbitltd" %% "spoiwo" % "2.2.2"
 )
 ```
 

--- a/build.sbt
+++ b/build.sbt
@@ -31,14 +31,14 @@ lazy val commonSettings = Seq(
   publishMavenStyle := true,
   Test / publishArtifact := false,
   resolvers += "Apache Releases" at "https://repository.apache.org/content/repositories/releases",
-  version := "2.2.1",
+  version := "2.2.2",
   versionScheme := Some("early-semver"),
   publishTo := sonatypePublishToBundle.value,
   pomExtra := pomDetails,
   libraryDependencies ++= Seq(
     "com.github.tototoshi" %% "scala-csv" % "1.3.10",
-    "org.apache.poi" % "poi" % "5.2.3",
-    "org.apache.poi" % "poi-ooxml" % "5.2.3",
+    "org.apache.poi" % "poi" % "5.4.1",
+    "org.apache.poi" % "poi-ooxml" % "5.4.1",
     "org.scalatest" %% "scalatest" % "3.2.11" % Test
   )
 )


### PR DESCRIPTION
https://nvd.nist.gov/vuln/detail/CVE-2025-31672

Improper Input Validation vulnerability in Apache POI. The issue affects the parsing of OOXML format files like xlsx, docx and pptx. These file formats are basically zip files and it is possible for malicious users to add zip entries with duplicate names (including the path) in the zip. In this case, products reading the affected file could read different data because 1 of the zip entries with the duplicate name is selected over another but different products may choose a different zip entry. This issue affects Apache POI poi-ooxml before 5.4.0. poi-ooxml 5.4.0 has a check that throws an exception if zip entries with duplicate file names are found in the input file. Users are recommended to upgrade to version poi-ooxml 5.4.0, which fixes the issue. Please read https://poi.apache.org/security.html for recommendations about how to use the POI libraries securely.